### PR TITLE
Draft 3 ppt chart events + cross-namespace ChartType for OASP #2

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -11,6 +11,42 @@
 
 ### 新增
 
+**`/ppt` 命名空间补齐图表（Chart）能力（3 个 Draft 事件 + 1 个跨命名空间数据结构组）**
+
+| 变更类型 | 事件 / 类型 | 说明 |
+|----------|-------------|------|
+| 新增 | `ppt:insert:chart` | 📋 Draft，按 ChartData 在指定幻灯片插入图表 |
+| 新增 | `ppt:get:chart` | 📋 Draft，按 elementId 读取图表完整数据 |
+| 新增 | `ppt:update:chart` | 📋 Draft，按 elementId 更新图表数据/类型/标题/展示选项（部分更新） |
+| 提升为跨命名空间 | `ChartType` | 从 `data-structures.md` 的 `Excel 相关` 段移至新建的 `图表相关` 段，并扩展为 10 个 Office.js `Excel.ChartType` 对齐值（新增 `ColumnClustered` / `ColumnStacked` / `BarClustered` / `LineMarkers` / `Radar`，原 `Column` / `Bar` 高层值移除以避免歧义）。破坏性变更，但 Excel 命名空间整体仍处 📋 Draft 阶段，影响面可控 |
+| 新增 | `ChartSeries` | 数据结构，承载图表单条数据系列（name / values / color） |
+| 新增 | `ChartData` | 数据结构，承载图表逻辑数据（chartType / categories / series / title / showLegend / showDataLabels），供 PPT/Excel 共用 |
+| 新增 | 错误码 `3015 INVALID_CHART_DATA` | series.values 长度与 categories 不一致专用错误码 |
+| 新增（说明） | `ppt:delete:element` 描述 | 追加 `亦适用于图表（Chart）元素删除` admonition；不新增独立 `ppt:delete:chart`，复用通用删除入口 |
+
+**动机**: PPT 是图表高频使用场景（业绩报告、产品方案）。当前 OASP `/ppt` 命名空间已能插入文本框、形状、图片、表格，**唯独不能插入图表**——`Chart` 仅在 `SlideElementType` 中作为枚举出现并可被 `ppt:get:slideElements.includeCharts` 过滤，但没有任何对图表本身的增改查事件。AI 体验上只能让用户手动插入图表后再让 AI 改文字，断裂明显。
+
+**设计取舍**:
+
+- **Server-handled OOXML 路径**：PowerPoint Office.js 当前不暴露图表创建与数据更新接口（参见 [office-js#5463](https://github.com/OfficeDev/office-js/issues/5463)），本批 chart 类事件由 OASP Server 端通过 OOXML 离线工具（如 `python-pptx`）直接修改 .pptx 文件后再让 Add-In 重新加载文档。事件文档顶部 admonition 明确标注延迟 >1s、要求 Add-In 调用前 `save()`、并发需串行化等副作用约束
+- **复用 `ppt:delete:element`**：删除统一走通用入口，避免新增 `ppt:delete:chart` 造成 API 表面冗余
+- **`ChartType` 与 Office.js 对齐**：枚举值与 `Excel.ChartType` 完全一致（如 `ColumnClustered` / `LineMarkers`），消费方可直接 `cast`，无需维护额外映射表
+- **`ChartType` 跨命名空间提升**：未来 Excel `excel:insert:chart` 可直接复用同一枚举与 `ChartData` / `ChartSeries`，避免双套语义
+- **不新增 `update:element` 字段塞图表**：`ppt:update:element` 仅承担几何属性，图表的「数据/类型/标题」是图表特有语义，独立 `update:chart` 边界更清晰、错误恢复粒度更细
+
+**兼容性**:
+
+- 新增事件 + 新增可选字段，不影响 `/word` 等其它命名空间
+- `ChartType` 枚举值变更属破坏性变更，但 Excel 侧 `excel:insert:chart` 尚未定义、PPT 侧本就无 chart 事件，实际无在用消费方
+- 新事件初始标记 📋 Draft，待消费方（office4ai）落地稳定后再统一转 ✅ Stable
+
+**相关 Issue / 工单**:
+
+- 协议侧：[oasp-protocol#2](https://github.com/A2C-SMCP/oasp-protocol/issues/2)（Milestone: PPT Chart Capabilities）
+- 消费方实现：office4ai（Server 端 python-pptx OOXML 拦截，待 issue 跟进）
+
+---
+
 **`/word` 命名空间补齐表格操作能力（4 个 Draft 事件）**
 
 | 变更类型 | 事件 / 类型 | 说明 |

--- a/docs/specification/data-structures.md
+++ b/docs/specification/data-structures.md
@@ -381,20 +381,59 @@ type CellValueType =
   | "Empty";               // 空值
 ```
 
+---
+
+## 图表相关
+
+> 跨命名空间通用图表数据结构。供 PPT (`ppt:insert:chart` / `ppt:get:chart` / `ppt:update:chart`) 与未来 Excel (`excel:insert:chart` 等) 共用。
+
 ### ChartType
 
-图表类型（常用）。
+图表类型枚举，命名与 [`Excel.ChartType`](https://learn.microsoft.com/en-us/javascript/api/excel/excel.charttype) 保持一致，便于消费方直接 cast。
 
 ```typescript
 type ChartType =
-  | "Column"               // 柱形图
-  | "Bar"                  // 条形图
+  | "ColumnClustered"      // 簇状柱形图
+  | "ColumnStacked"        // 堆积柱形图
+  | "BarClustered"         // 簇状条形图
   | "Line"                 // 折线图
+  | "LineMarkers"          // 带标记折线图
   | "Pie"                  // 饼图
+  | "Doughnut"             // 圆环图
   | "Area"                 // 面积图
   | "Scatter"              // 散点图
-  | "Doughnut";            // 圆环图
+  | "Radar";               // 雷达图
 ```
+
+### ChartSeries
+
+图表的单条数据系列。
+
+```typescript
+interface ChartSeries {
+  name: string;            // 系列名称（图例显示）
+  values: number[];        // 数值数组，长度需 = ChartData.categories.length
+  color?: string;          // 系列颜色（hex，如 "#4472C4"），缺省使用主题色
+}
+```
+
+### ChartData
+
+图表的逻辑数据与展示选项（不含几何位置）。
+
+```typescript
+interface ChartData {
+  chartType: ChartType;    // 图表类型
+  categories: string[];    // X 轴/分类轴标签
+  series: ChartSeries[];   // 数据系列（≥1）
+  title?: string;          // 图表标题
+  showLegend?: boolean;    // 是否显示图例，默认 true
+  showDataLabels?: boolean;// 是否显示数据标签，默认 false
+}
+```
+
+!!! warning "数据维度校验"
+    每个 `ChartSeries.values` 长度必须等于 `categories.length`，否则返回 `3015 INVALID_CHART_DATA`。
 
 ---
 

--- a/docs/specification/error-handling.md
+++ b/docs/specification/error-handling.md
@@ -97,6 +97,7 @@ interface ErrorResponse {
 | `3012` | `SEARCH_NO_MATCH` | 搜索无匹配结果 |
 | `3013` | `NO_TABLE_AT_CURSOR` | 缺省 `tableId` 时光标未落在任何表格内 |
 | `3014` | `ALREADY_MERGED` | 目标合并区域内已存在合并冲突，无法再次合并 |
+| `3015` | `INVALID_CHART_DATA` | 图表数据维度不一致（series.values 长度与 categories 不匹配） |
 
 ### 4xxx - 参数验证错误
 

--- a/docs/specification/events-ppt.md
+++ b/docs/specification/events-ppt.md
@@ -33,11 +33,14 @@
 | [ppt:insert:shape](#pptinsertshape) | 📋 Draft | 插入形状 |
 | [ppt:insert:image](#pptinsertimage) | 📋 Draft | 插入图片 |
 | [ppt:insert:table](#pptinserttable) | 📋 Draft | 插入表格 |
+| [ppt:insert:chart](#pptinsertchart) | 📋 Draft | 插入图表（Server OOXML 离线处理） |
 | [ppt:update:textBox](#pptupdatetextbox) | 📋 Draft | 更新文本框内容/样式 |
-| [ppt:delete:element](#pptdeleteelement) | 📋 Draft | 删除指定元素 |
+| [ppt:delete:element](#pptdeleteelement) | 📋 Draft | 删除指定元素（亦适用于图表删除） |
 | [ppt:update:image](#pptupdateimage) | 📋 Draft | 替换图片内容 |
 | [ppt:update:tableCell](#pptupdatetablecell) | 📋 Draft | 更新表格单元格 |
 | [ppt:update:tableRowColumn](#pptupdatetablerowcolumn) | 📋 Draft | 更新表格行/列内容 |
+| [ppt:get:chart](#pptgetchart) | 📋 Draft | 读取图表数据（Server OOXML 离线处理） |
+| [ppt:update:chart](#pptupdatechart) | 📋 Draft | 更新图表数据/类型/标题（Server OOXML 离线处理） |
 
 ### 样式格式类（Server → AddIn，请求-响应）
 
@@ -1234,6 +1237,206 @@ interface InsertTableResponse {
 
 ---
 
+### ppt:insert:chart
+
+**方向**: Server → AddIn（请求-响应）
+
+**状态**: 📋 Draft
+
+**说明**: 在指定幻灯片插入图表（柱形/折线/饼图等），含数据系列与基础展示选项。
+
+!!! warning "Server 端 OOXML 离线处理（适用于 ppt:insert:chart / ppt:get:chart / ppt:update:chart）"
+    PowerPoint JavaScript API 当前不暴露图表创建与数据更新接口（参见 [office-js#5463](https://github.com/OfficeDev/office-js/issues/5463)）。本节 chart 类事件**不经 Add-In Office.js 路径**，由 OASP Server 端使用 OOXML 离线工具（如 `python-pptx`）直接修改 .pptx 文件后再通知 Add-In 重新加载文档。
+
+    **副作用与约束**：
+
+    - 预期延迟 >1s（取决于文档大小与磁盘 I/O）
+    - 调用前 Add-In 应已 `save()`，否则未保存的本地修改会被覆盖
+    - 完成后 Add-In 需重新打开/刷新文档以呈现新图表
+    - 同一文档的并发 chart 调用应串行化，避免 OOXML 写入冲突
+    - 相关数据结构（`ChartData` / `ChartType` / `ChartSeries`）定义见 [data-structures.md#ChartType](data-structures.md#charttype)
+
+**请求数据**:
+
+```typescript
+interface InsertChartRequest {
+  requestId: string;            // 请求 ID (UUID)
+  documentUri: string;          // 文档 URI
+  timestamp?: number;           // 请求时间戳（毫秒），可选
+  chart: ChartData;             // 图表逻辑数据
+  options?: ChartInsertOptions; // 几何与目标位置（可选）
+}
+
+interface ChartInsertOptions {
+  slideIndex?: number;          // 目标幻灯片索引（从 0 开始），默认当前幻灯片
+  left?: number;                // X 坐标（磅），默认居中
+  top?: number;                 // Y 坐标（磅），默认居中
+  width?: number;               // 宽度（磅），默认 480
+  height?: number;              // 高度（磅），默认 320
+}
+```
+
+**请求示例**:
+
+```json
+{
+  "requestId": "a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d",
+  "documentUri": "file:///Users/john/Documents/q1-report.pptx",
+  "chart": {
+    "chartType": "ColumnClustered",
+    "categories": ["Jan", "Feb", "Mar"],
+    "series": [
+      { "name": "Revenue", "values": [120, 135, 158] },
+      { "name": "Cost",    "values": [80,  90,  102] }
+    ],
+    "title": "Q1 业绩",
+    "showLegend": true
+  },
+  "options": { "slideIndex": 1, "width": 520, "height": 340 }
+}
+```
+
+**响应数据**:
+
+```typescript
+interface InsertChartResponse {
+  requestId: string;
+  success: boolean;
+  data?: {
+    elementId: string;          // 创建的图表元素 ID
+    slideIndex: number;         // 实际插入的幻灯片索引
+    chartType: ChartType;
+    seriesCount: number;
+    categoryCount: number;
+    left: number;               // 实际 X 坐标（磅）
+    top: number;                // 实际 Y 坐标（磅）
+    width: number;              // 实际宽度（磅）
+    height: number;             // 实际高度（磅）
+  };
+  error?: ErrorResponse;
+  timestamp: number;
+}
+```
+
+**可能的错误**:
+
+| 错误码 | 说明 |
+|--------|------|
+| 4001 | `MISSING_PARAM` - 缺少 chart.chartType / categories / series |
+| 4002 | `INVALID_PARAM` - chartType 取值不在 ChartType 枚举内 |
+| 3015 | `INVALID_CHART_DATA` - series.values 长度与 categories 不一致 |
+| 3001 | `DOCUMENT_NOT_FOUND` - 文档未找到 |
+| 3003 | `DOCUMENT_READ_ONLY` - 文档为只读模式 |
+| 3004 | `OPERATION_FAILED` - OOXML 写入失败 |
+
+---
+
+### ppt:get:chart
+
+**方向**: Server → AddIn（请求-响应）
+
+**状态**: 📋 Draft
+
+**说明**: 读取指定 `elementId` 图表的当前数据（类型、分类、系列、标题、展示选项）。
+
+> Server-handled OOXML 路径与并发约束见 [`ppt:insert:chart` 顶部 admonition](#pptinsertchart)。
+
+**请求数据**:
+
+```typescript
+interface GetChartRequest {
+  requestId: string;
+  documentUri: string;
+  timestamp?: number;
+  elementId: string;            // 图表元素 ID（必需）
+  slideIndex?: number;          // 可选，仅作为加速定位提示；不一致以 elementId 为准
+}
+```
+
+**响应数据**:
+
+```typescript
+interface GetChartResponse {
+  requestId: string;
+  success: boolean;
+  data?: {
+    elementId: string;
+    slideIndex: number;
+    chart: ChartData;           // 完整图表数据（与 insert 请求镜像）
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  };
+  error?: ErrorResponse;
+  timestamp: number;
+}
+```
+
+**可能的错误**:
+
+| 错误码 | 说明 |
+|--------|------|
+| 4001 | `MISSING_PARAM` - 缺少 elementId |
+| 3010 | `ELEMENT_NOT_FOUND` - 指定 elementId 不存在或不是图表元素 |
+| 3001 | `DOCUMENT_NOT_FOUND` - 文档未找到 |
+
+---
+
+### ppt:update:chart
+
+**方向**: Server → AddIn（请求-响应）
+
+**状态**: 📋 Draft
+
+**说明**: 更新已存在图表的数据、类型、标题或展示选项。所有字段可选；提供哪个字段就只更新哪个。
+
+> Server-handled OOXML 路径与并发约束见 [`ppt:insert:chart` 顶部 admonition](#pptinsertchart)。
+
+**请求数据**:
+
+```typescript
+interface UpdateChartRequest {
+  requestId: string;
+  documentUri: string;
+  timestamp?: number;
+  elementId: string;            // 图表元素 ID（必需）
+  chart: Partial<ChartData>;    // 部分更新；categories/series 一旦提供即整体替换
+}
+```
+
+!!! warning "categories 与 series 同步替换"
+    若同时提供 `categories` 与 `series`，两者必须一致（每个 `ChartSeries.values.length === categories.length`）。仅替换其中一方时，未提供的一方保持原值，但 Server 会重新校验匹配关系，不一致时返回 `3015`。
+
+**响应数据**:
+
+```typescript
+interface UpdateChartResponse {
+  requestId: string;
+  success: boolean;
+  data?: {
+    elementId: string;
+    updatedFields: string[];    // 实际生效的字段列表（如 ["title","series"]）
+  };
+  error?: ErrorResponse;
+  timestamp: number;
+}
+```
+
+**可能的错误**:
+
+| 错误码 | 说明 |
+|--------|------|
+| 4001 | `MISSING_PARAM` - 缺少 elementId |
+| 4002 | `INVALID_PARAM` - chartType 取值不在 ChartType 枚举内 |
+| 3010 | `ELEMENT_NOT_FOUND` - 指定 elementId 不存在或不是图表元素 |
+| 3015 | `INVALID_CHART_DATA` - 替换后 series.values 长度与 categories 不一致 |
+| 3001 | `DOCUMENT_NOT_FOUND` - 文档未找到 |
+| 3003 | `DOCUMENT_READ_ONLY` - 文档为只读模式 |
+| 3004 | `OPERATION_FAILED` - OOXML 写入失败 |
+
+---
+
 ### ppt:update:textBox
 
 **方向**: Server → AddIn（请求-响应）
@@ -1364,6 +1567,9 @@ interface UpdateTextBoxResponse {
 **状态**: 📋 Draft
 
 **说明**: 删除幻灯片上的指定元素。支持单个或批量删除。
+
+!!! info "亦适用于图表（Chart）元素删除"
+    无独立的 `ppt:delete:chart` 事件。删除图表元素请直接传入 chart 对应的 `elementId`（可由 `ppt:get:slideElements` / `ppt:insert:chart` 响应获取）。
 
 **请求数据**:
 


### PR DESCRIPTION
## Summary

补齐 OASP `/ppt` 命名空间图表（Chart）能力，并将 `ChartType` 提升为跨命名空间通用数据结构。

- 新增 3 个 📋 Draft 事件：`ppt:insert:chart` / `ppt:get:chart` / `ppt:update:chart`
- `ChartType` 由 `data-structures.md` 的 `Excel 相关` 段移至新建的 `图表相关` 段，扩展为 10 个与 `Excel.ChartType` 对齐的值
- 新增 `ChartSeries` / `ChartData` 数据结构，PPT / Excel 共用
- 新增错误码 `3015 INVALID_CHART_DATA`
- `ppt:delete:element` 描述追加 `亦适用于图表（Chart）元素删除`，复用通用删除入口（不新增 `ppt:delete:chart`）
- Changelog 累积至 `[Unreleased]`，**不**在本 PR 内 bump 版本号

## 关键设计取舍

- **Server-handled OOXML 路径**：PowerPoint Office.js 当前不暴露图表创建/更新接口（参见 [office-js#5463](https://github.com/OfficeDev/office-js/issues/5463)）。3 个 chart 事件由 OASP Server 端使用 OOXML 离线工具（如 `python-pptx`）直接修改 .pptx 后让 Add-In 重新加载文档；事件文档顶部 admonition 明确标注 >1s 延迟、调用前需 `save()`、并发需串行化等副作用约束
- **`ChartType` 与 Office.js 对齐**：枚举值与 `Excel.ChartType` 完全一致（如 `ColumnClustered` / `LineMarkers`），消费方可直接 cast，无需维护额外映射表
- **跨命名空间提升**：未来 Excel `excel:insert:chart` 可直接复用同一枚举与 `ChartData` / `ChartSeries`，避免双套语义
- **不塞 `update:element`**：`ppt:update:element` 仅承担几何属性，图表的「数据/类型/标题」是图表特有语义，独立 `update:chart` 边界更清晰、错误恢复粒度更细

## 兼容性

- 新增事件 + 新增可选字段，不影响 `/word` 等其它命名空间
- `ChartType` 枚举值变更属破坏性变更，但 Excel 侧 `excel:insert:chart` 尚未定义、PPT 侧本就无 chart 事件，实际无在用消费方
- 新事件初始标记 📋 Draft，待消费方（office4ai）落地稳定后再统一转 ✅ Stable

## Test plan

- [x] `uv run mkdocs build` 无新增 warning（仅 2 个 pre-existing 锚点警告与本 PR 无关）
- [ ] 文档预览（mkdocs serve）人工核对 3 个 chart 事件锚点 + `data-structures.md#charttype` 跳转
- [ ] Reviewer 评审 ChartType 值集是否覆盖业务高频图表
- [ ] Reviewer 评审 Server-handled admonition 是否充分覆盖延迟/并发/save 约束

## Refs

- Issue: #2
- Milestone: PPT Chart Capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)