### PR TITLE
Refactor ChartData to discriminated union for LLM schema discoverability

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -15,13 +15,13 @@
 
 | 变更类型 | 事件 / 类型 | 说明 |
 |----------|-------------|------|
-| 新增 | `ppt:insert:chart` | 📋 Draft，按 ChartData 在指定幻灯片插入图表 |
-| 新增 | `ppt:get:chart` | 📋 Draft，按 elementId 读取图表完整数据 |
-| 新增 | `ppt:update:chart` | 📋 Draft，按 elementId 更新图表数据/类型/标题/展示选项（部分更新） |
-| 提升为跨命名空间 | `ChartType` | 从 `data-structures.md` 的 `Excel 相关` 段移至新建的 `图表相关` 段，并扩展为 10 个 Office.js `Excel.ChartType` 对齐值（新增 `ColumnClustered` / `ColumnStacked` / `BarClustered` / `LineMarkers` / `Radar`，原 `Column` / `Bar` 高层值移除以避免歧义）。破坏性变更，但 Excel 命名空间整体仍处 📋 Draft 阶段，影响面可控 |
-| 新增 | `ChartSeries` | 数据结构，承载图表单条数据系列（name / values / color） |
-| 新增 | `ChartData` | 数据结构，承载图表逻辑数据（chartType / categories / series / title / showLegend / showDataLabels），供 PPT/Excel 共用 |
-| 新增 | 错误码 `3015 INVALID_CHART_DATA` | series.values 长度与 categories 不一致专用错误码 |
+| 新增 | `ppt:insert:chart` | 📋 Draft，按 `ChartData` discriminated union 在指定幻灯片插入图表 |
+| 新增 | `ppt:get:chart` | 📋 Draft，按 elementId 读取图表完整数据，响应 `chart` 字段为同一 union |
+| 新增 | `ppt:update:chart` | 📋 Draft，按 elementId 更新图表数据/类型/标题/展示选项；`chart.chartType` 为必需 discriminator |
+| 提升为跨命名空间 | `ChartType` | 从 `data-structures.md` 的 `Excel 相关` 段移至新建的 `图表相关` 段，并扩展为 10 个 Office.js `Excel.ChartType` 对齐值（新增 `ColumnClustered` / `ColumnStacked` / `BarClustered` / `LineMarkers` / `Radar`，原 `Column` / `Bar` 高层值移除以避免歧义）。`ChartType` 进一步细分为 `CategoricalChartType`（9 个）+ `ScatterChartType`（"Scatter"）。破坏性变更，但 Excel 命名空间整体仍处 📋 Draft 阶段，影响面可控 |
+| 新增 | `CategoricalSeries` / `ScatterSeries` / `ScatterPoint` | 数据结构，分别承载分类型图表的数据系列（name / values / color）与散点型图表的数据系列（name / points / color）。取代原始 `ChartSeries` 单一定义 |
+| 新增 | `ChartData` discriminated union | `ChartData = CategoricalChartData \| ScatterChartData`，由 `chartType` 字段判别。Categorical 含 `categories: string[]` + `series: CategoricalSeries[]`；Scatter 不含 `categories`，X 由 `series[].points[].x` 提供。供 PPT / Excel 共用 |
+| 新增 | 错误码 `3015 INVALID_CHART_DATA` | 多用途：categorical 维度不一致 / scatter `points` 为空或含非法值 / 跨 variant 切换未补齐 `series` |
 | 新增（说明） | `ppt:delete:element` 描述 | 追加 `亦适用于图表（Chart）元素删除` admonition；不新增独立 `ppt:delete:chart`，复用通用删除入口 |
 
 **动机**: PPT 是图表高频使用场景（业绩报告、产品方案）。当前 OASP `/ppt` 命名空间已能插入文本框、形状、图片、表格，**唯独不能插入图表**——`Chart` 仅在 `SlideElementType` 中作为枚举出现并可被 `ppt:get:slideElements.includeCharts` 过滤，但没有任何对图表本身的增改查事件。AI 体验上只能让用户手动插入图表后再让 AI 改文字，断裂明显。
@@ -29,21 +29,25 @@
 **设计取舍**:
 
 - **Server-handled OOXML 路径**：PowerPoint Office.js 当前不暴露图表创建与数据更新接口（参见 [office-js#5463](https://github.com/OfficeDev/office-js/issues/5463)），本批 chart 类事件由 OASP Server 端通过 OOXML 离线工具（如 `python-pptx`）直接修改 .pptx 文件后再让 Add-In 重新加载文档。事件文档顶部 admonition 明确标注延迟 >1s、要求 Add-In 调用前 `save()`、并发需串行化等副作用约束
+- **`ChartData` 采用 discriminated union（`chartType` 为 discriminator）**：`Scatter` 与分类型图表的数据形状本质不同（X 是连续数值 vs 离散标签）。如果硬塞同一 schema（让 `categories` 在 Scatter 时存数字字符串），LLM 在 MCP 工具的 JSON Schema 里看不到这个隐式约束，调用错误率高。Discriminated union 让 LLM 一选定 `chartType`，schema 就限定可填字段；JSON Schema 用 `oneOf` + `discriminator: { propertyName: "chartType" }` 落地，Pydantic / FastMCP 用 `Annotated[Union[...], Field(discriminator="chartType")]`
+- **`update:chart` 强制要求 `chartType`**：让 schema 层能选中正确 variant；AI 调用前先 `get:chart` 读取并回填，比让 schema 层放任所有字段都 optional 更可靠
 - **复用 `ppt:delete:element`**：删除统一走通用入口，避免新增 `ppt:delete:chart` 造成 API 表面冗余
 - **`ChartType` 与 Office.js 对齐**：枚举值与 `Excel.ChartType` 完全一致（如 `ColumnClustered` / `LineMarkers`），消费方可直接 `cast`，无需维护额外映射表
-- **`ChartType` 跨命名空间提升**：未来 Excel `excel:insert:chart` 可直接复用同一枚举与 `ChartData` / `ChartSeries`，避免双套语义
+- **`ChartType` 跨命名空间提升**：未来 Excel `excel:insert:chart` 可直接复用同一枚举与 `ChartData` 联合，避免双套语义
 - **不新增 `update:element` 字段塞图表**：`ppt:update:element` 仅承担几何属性，图表的「数据/类型/标题」是图表特有语义，独立 `update:chart` 边界更清晰、错误恢复粒度更细
 
 **兼容性**:
 
 - 新增事件 + 新增可选字段，不影响 `/word` 等其它命名空间
 - `ChartType` 枚举值变更属破坏性变更，但 Excel 侧 `excel:insert:chart` 尚未定义、PPT 侧本就无 chart 事件，实际无在用消费方
+- discriminated union 形态在本 [Unreleased] 周期内确定（含中途 PR #4 → PR #5 的 schema 重构），无对外发版的旧 shape 残留
 - 新事件初始标记 📋 Draft，待消费方（office4ai）落地稳定后再统一转 ✅ Stable
 
 **相关 Issue / 工单**:
 
 - 协议侧：[oasp-protocol#2](https://github.com/A2C-SMCP/oasp-protocol/issues/2)（Milestone: PPT Chart Capabilities）
-- 消费方实现：office4ai（Server 端 python-pptx OOXML 拦截，待 issue 跟进）
+- 协议 PR：[#4](https://github.com/A2C-SMCP/oasp-protocol/pull/4)（首版 categorical-only schema）→ [#5](https://github.com/A2C-SMCP/oasp-protocol/pull/5)（重构为 discriminated union，提升 LLM 可发现性）
+- 消费方实现：[office4ai#9](https://github.com/JIAQIA/office4ai/issues/9)（Server 端 python-pptx OOXML 拦截）
 
 ---
 

--- a/docs/specification/data-structures.md
+++ b/docs/specification/data-structures.md
@@ -389,10 +389,11 @@ type CellValueType =
 
 ### ChartType
 
-图表类型枚举，命名与 [`Excel.ChartType`](https://learn.microsoft.com/en-us/javascript/api/excel/excel.charttype) 保持一致，便于消费方直接 cast。
+图表类型总枚举，命名与 [`Excel.ChartType`](https://learn.microsoft.com/en-us/javascript/api/excel/excel.charttype) 保持一致，便于消费方直接 cast。`ChartType` 在数据形状上分两类，`ChartData` 据此采用 discriminated union 表达。
 
 ```typescript
-type ChartType =
+// 分类型图表：X 轴是离散标签，Y 是数值
+type CategoricalChartType =
   | "ColumnClustered"      // 簇状柱形图
   | "ColumnStacked"        // 堆积柱形图
   | "BarClustered"         // 簇状条形图
@@ -401,39 +402,76 @@ type ChartType =
   | "Pie"                  // 饼图
   | "Doughnut"             // 圆环图
   | "Area"                 // 面积图
-  | "Scatter"              // 散点图
   | "Radar";               // 雷达图
+
+// 散点型图表：每个数据点自带 (x, y) 数对
+type ScatterChartType = "Scatter";
+
+type ChartType = CategoricalChartType | ScatterChartType;
 ```
 
-### ChartSeries
+### CategoricalSeries
 
-图表的单条数据系列。
+分类型图表的单条数据系列（柱形/折线/饼图等使用）。
 
 ```typescript
-interface ChartSeries {
+interface CategoricalSeries {
   name: string;            // 系列名称（图例显示）
-  values: number[];        // 数值数组，长度需 = ChartData.categories.length
+  values: number[];        // Y 数值数组，长度需 = CategoricalChartData.categories.length
   color?: string;          // 系列颜色（hex，如 "#4472C4"），缺省使用主题色
+}
+```
+
+### ScatterSeries
+
+散点型图表的单条数据系列。
+
+```typescript
+interface ScatterSeries {
+  name: string;            // 系列名称
+  points: ScatterPoint[];  // 数据点数组（≥1）
+  color?: string;          // 系列颜色（hex），缺省使用主题色
+}
+
+interface ScatterPoint {
+  x: number;               // X 坐标（连续数值轴）
+  y: number;               // Y 坐标
 }
 ```
 
 ### ChartData
 
-图表的逻辑数据与展示选项（不含几何位置）。
+图表的逻辑数据与展示选项（不含几何位置）。`ChartData` 是 discriminated union，由 `chartType` 字段决定具体形状：
 
 ```typescript
-interface ChartData {
-  chartType: ChartType;    // 图表类型
-  categories: string[];    // X 轴/分类轴标签
-  series: ChartSeries[];   // 数据系列（≥1）
-  title?: string;          // 图表标题
-  showLegend?: boolean;    // 是否显示图例，默认 true
-  showDataLabels?: boolean;// 是否显示数据标签，默认 false
+type ChartData = CategoricalChartData | ScatterChartData;
+
+interface CategoricalChartData {
+  chartType: CategoricalChartType;     // 9 个分类型枚举之一（不含 "Scatter"）
+  categories: string[];                // X 轴离散标签（如 ["Jan","Feb","Mar"]）
+  series: CategoricalSeries[];         // 数据系列（≥1）
+  title?: string;                      // 图表标题
+  showLegend?: boolean;                // 是否显示图例，默认 true
+  showDataLabels?: boolean;            // 是否显示数据标签，默认 false
+}
+
+interface ScatterChartData {
+  chartType: "Scatter";                // 字面量
+  series: ScatterSeries[];             // 数据系列（≥1）；X 由 series[].points[].x 提供，无 categories
+  title?: string;
+  showLegend?: boolean;
+  showDataLabels?: boolean;
 }
 ```
 
+!!! info "为什么用 discriminated union"
+    `ChartType` 在数据形状上不一致：分类型图表用 `categories + series.values`（X 是离散标签），散点图用 `series.points`（X 是连续数值，每个点自带 (x,y)）。把它们硬塞进同一个 schema（如让 `categories` 在 Scatter 时存数字字符串）会让 LLM 在 MCP 工具 schema 里看不到这个隐式约束。Discriminated union 让 LLM 一选定 `chartType`，schema 就自动限定可填字段。
+
+    JSON Schema 落地建议使用 `oneOf` + `discriminator: { propertyName: "chartType" }`；Pydantic / FastMCP 使用 `Annotated[Union[...], Field(discriminator="chartType")]`。
+
 !!! warning "数据维度校验"
-    每个 `ChartSeries.values` 长度必须等于 `categories.length`，否则返回 `3015 INVALID_CHART_DATA`。
+    - `CategoricalChartData`：每个 `CategoricalSeries.values` 长度必须等于 `categories.length`，否则返回 `3015 INVALID_CHART_DATA`
+    - `ScatterChartData`：每个 `ScatterSeries.points` 长度 ≥ 1，`x`/`y` 必须为有限数（非 `NaN` / `Infinity`），否则返回 `3015 INVALID_CHART_DATA`
 
 ---
 

--- a/docs/specification/events-ppt.md
+++ b/docs/specification/events-ppt.md
@@ -1243,7 +1243,7 @@ interface InsertTableResponse {
 
 **状态**: 📋 Draft
 
-**说明**: 在指定幻灯片插入图表（柱形/折线/饼图等），含数据系列与基础展示选项。
+**说明**: 在指定幻灯片插入图表（柱形/折线/饼/散点等），含数据系列与基础展示选项。
 
 !!! warning "Server 端 OOXML 离线处理（适用于 ppt:insert:chart / ppt:get:chart / ppt:update:chart）"
     PowerPoint JavaScript API 当前不暴露图表创建与数据更新接口（参见 [office-js#5463](https://github.com/OfficeDev/office-js/issues/5463)）。本节 chart 类事件**不经 Add-In Office.js 路径**，由 OASP Server 端使用 OOXML 离线工具（如 `python-pptx`）直接修改 .pptx 文件后再通知 Add-In 重新加载文档。
@@ -1254,7 +1254,7 @@ interface InsertTableResponse {
     - 调用前 Add-In 应已 `save()`，否则未保存的本地修改会被覆盖
     - 完成后 Add-In 需重新打开/刷新文档以呈现新图表
     - 同一文档的并发 chart 调用应串行化，避免 OOXML 写入冲突
-    - 相关数据结构（`ChartData` / `ChartType` / `ChartSeries`）定义见 [data-structures.md#ChartType](data-structures.md#charttype)
+    - 相关数据结构（`ChartData` discriminated union / `ChartType` / `CategoricalSeries` / `ScatterSeries`）定义见 [data-structures.md#ChartType](data-structures.md#charttype)
 
 **请求数据**:
 
@@ -1263,7 +1263,7 @@ interface InsertChartRequest {
   requestId: string;            // 请求 ID (UUID)
   documentUri: string;          // 文档 URI
   timestamp?: number;           // 请求时间戳（毫秒），可选
-  chart: ChartData;             // 图表逻辑数据
+  chart: ChartData;             // discriminated union: CategoricalChartData | ScatterChartData
   options?: ChartInsertOptions; // 几何与目标位置（可选）
 }
 
@@ -1276,7 +1276,15 @@ interface ChartInsertOptions {
 }
 ```
 
-**请求示例**:
+!!! info "schema 形状由 chartType 决定"
+    `chart.chartType` 是 discriminator：
+    
+    - `chartType ∈ CategoricalChartType`（9 个分类型）→ `chart` 形状为 `CategoricalChartData`，需 `categories: string[]` + `series: CategoricalSeries[]`（每条 `series.values` 长度必须等于 `categories.length`）
+    - `chartType === "Scatter"` → `chart` 形状为 `ScatterChartData`，需 `series: ScatterSeries[]`（每条 series 自带 `points: { x, y }[]`，**不传 `categories`**）
+    
+    JSON Schema 应使用 `oneOf` + `discriminator: { propertyName: "chartType" }` 表达，让消费方（LLM）一选定 `chartType` 就能看到对应的必填字段。
+
+**请求示例 — 分类型图表（柱形图）**:
 
 ```json
 {
@@ -1296,6 +1304,32 @@ interface ChartInsertOptions {
 }
 ```
 
+**请求示例 — 散点图**:
+
+```json
+{
+  "requestId": "b2c3d4e5-f6a7-4b6c-9d8e-0f1a2b3c4d5e",
+  "documentUri": "file:///Users/john/Documents/ads-analysis.pptx",
+  "chart": {
+    "chartType": "Scatter",
+    "series": [
+      {
+        "name": "Ads vs Sales",
+        "points": [
+          { "x": 1000, "y": 50  },
+          { "x": 1500, "y": 80  },
+          { "x": 3000, "y": 200 },
+          { "x": 5000, "y": 350 },
+          { "x": 8000, "y": 600 }
+        ]
+      }
+    ],
+    "title": "广告投入 vs 销售额"
+  },
+  "options": { "slideIndex": 2 }
+}
+```
+
 **响应数据**:
 
 ```typescript
@@ -1305,9 +1339,8 @@ interface InsertChartResponse {
   data?: {
     elementId: string;          // 创建的图表元素 ID
     slideIndex: number;         // 实际插入的幻灯片索引
-    chartType: ChartType;
-    seriesCount: number;
-    categoryCount: number;
+    chartType: ChartType;       // 实际写入的图表类型
+    seriesCount: number;        // 系列数
     left: number;               // 实际 X 坐标（磅）
     top: number;                // 实际 Y 坐标（磅）
     width: number;              // 实际宽度（磅）
@@ -1318,13 +1351,15 @@ interface InsertChartResponse {
 }
 ```
 
+> 详细的 categories / points 内容如需读回，请调用 `ppt:get:chart`。
+
 **可能的错误**:
 
 | 错误码 | 说明 |
 |--------|------|
-| 4001 | `MISSING_PARAM` - 缺少 chart.chartType / categories / series |
-| 4002 | `INVALID_PARAM` - chartType 取值不在 ChartType 枚举内 |
-| 3015 | `INVALID_CHART_DATA` - series.values 长度与 categories 不一致 |
+| 4001 | `MISSING_PARAM` - 缺少 `chart.chartType`，或所选 variant 缺必填字段（categorical 缺 `categories`/`series`，scatter 缺 `series`） |
+| 4002 | `INVALID_PARAM` - `chartType` 不在枚举内，或字段形状与 `chartType` 所选 variant 不匹配（例如 `chartType: "Scatter"` 却传了 `categories`） |
+| 3015 | `INVALID_CHART_DATA` - categorical: `series[].values.length !== categories.length`；scatter: `points` 为空 / 含 NaN / Infinity |
 | 3001 | `DOCUMENT_NOT_FOUND` - 文档未找到 |
 | 3003 | `DOCUMENT_READ_ONLY` - 文档为只读模式 |
 | 3004 | `OPERATION_FAILED` - OOXML 写入失败 |
@@ -1337,7 +1372,7 @@ interface InsertChartResponse {
 
 **状态**: 📋 Draft
 
-**说明**: 读取指定 `elementId` 图表的当前数据（类型、分类、系列、标题、展示选项）。
+**说明**: 读取指定 `elementId` 图表的当前数据（类型、分类/数据点、系列、标题、展示选项）。
 
 > Server-handled OOXML 路径与并发约束见 [`ppt:insert:chart` 顶部 admonition](#pptinsertchart)。
 
@@ -1362,7 +1397,7 @@ interface GetChartResponse {
   data?: {
     elementId: string;
     slideIndex: number;
-    chart: ChartData;           // 完整图表数据（与 insert 请求镜像）
+    chart: ChartData;           // discriminated union；形状由其中的 chartType 字段决定
     left: number;
     top: number;
     width: number;
@@ -1372,6 +1407,8 @@ interface GetChartResponse {
   timestamp: number;
 }
 ```
+
+> 调用方在读取 `chart` 时应先看 `chart.chartType`：若属于 `CategoricalChartType`，存在 `categories` 与 `series[].values`；若为 `"Scatter"`，无 `categories`，数据在 `series[].points[]`。
 
 **可能的错误**:
 
@@ -1389,7 +1426,7 @@ interface GetChartResponse {
 
 **状态**: 📋 Draft
 
-**说明**: 更新已存在图表的数据、类型、标题或展示选项。所有字段可选；提供哪个字段就只更新哪个。
+**说明**: 更新已存在图表的数据、类型、标题或展示选项。除 `chartType`（discriminator，必需）外，其它字段均可选 — 只更新提供的字段。
 
 > Server-handled OOXML 路径与并发约束见 [`ppt:insert:chart` 顶部 admonition](#pptinsertchart)。
 
@@ -1401,12 +1438,73 @@ interface UpdateChartRequest {
   documentUri: string;
   timestamp?: number;
   elementId: string;            // 图表元素 ID（必需）
-  chart: Partial<ChartData>;    // 部分更新；categories/series 一旦提供即整体替换
+  chart: ChartUpdate;           // discriminated union
+}
+
+type ChartUpdate = CategoricalChartUpdate | ScatterChartUpdate;
+
+interface CategoricalChartUpdate {
+  chartType: CategoricalChartType;     // 必需，作为 discriminator
+  categories?: string[];               // 整体替换 X 轴标签（提供即覆盖）
+  series?: CategoricalSeries[];        // 整体替换数据系列（提供即覆盖）
+  title?: string | null;               // null 表示删除标题
+  showLegend?: boolean;
+  showDataLabels?: boolean;
+}
+
+interface ScatterChartUpdate {
+  chartType: "Scatter";                // 必需，作为 discriminator
+  series?: ScatterSeries[];            // 整体替换数据系列
+  title?: string | null;
+  showLegend?: boolean;
+  showDataLabels?: boolean;
 }
 ```
 
-!!! warning "categories 与 series 同步替换"
-    若同时提供 `categories` 与 `series`，两者必须一致（每个 `ChartSeries.values.length === categories.length`）。仅替换其中一方时，未提供的一方保持原值，但 Server 会重新校验匹配关系，不一致时返回 `3015`。
+!!! warning "chartType 必须显式提供"
+    AI 调用前应先用 `ppt:get:chart` 读取当前 `chartType` 并照原值回填。这样 schema 层就能选中正确的 variant、限定可更新字段，避免「以为在改 categorical 实际图表是 scatter」的乌龙。
+
+!!! warning "跨 variant 切换需补齐数据"
+    - 同 variant 内换 chartType（如 `Pie → ColumnClustered`，皆为 categorical）：可不传 `categories`/`series`，沿用原值
+    - 跨 variant 换 chartType（如 `Pie → Scatter`，或 `Scatter → Line`）：原数据形状不再适用，**必须同时传新 variant 的 `series`**（scatter 需 `series[].points`，categorical 需 `series[].values`），否则返回 `3015 INVALID_CHART_DATA`
+    - 同一 variant 内同时替换 `categories` + `series` 时，每条 `series.values.length` 必须等于新的 `categories.length`
+
+**请求示例 — 仅改标题**:
+
+```json
+{
+  "requestId": "c3d4e5f6-a7b8-4c7d-9e8f-1a2b3c4d5e6f",
+  "documentUri": "file:///Users/john/Documents/q1-report.pptx",
+  "elementId": "chart-001",
+  "chart": {
+    "chartType": "ColumnClustered",
+    "title": "Q1 业绩（修订版）"
+  }
+}
+```
+
+**请求示例 — 跨 variant 切换（Column → Scatter，必须补 points）**:
+
+```json
+{
+  "requestId": "d4e5f6a7-b8c9-4d8e-9f0a-2b3c4d5e6f7a",
+  "documentUri": "file:///Users/john/Documents/q1-report.pptx",
+  "elementId": "chart-001",
+  "chart": {
+    "chartType": "Scatter",
+    "series": [
+      {
+        "name": "Cost vs Revenue",
+        "points": [
+          { "x": 80, "y": 120 },
+          { "x": 90, "y": 135 },
+          { "x": 102, "y": 158 }
+        ]
+      }
+    ]
+  }
+}
+```
 
 **响应数据**:
 
@@ -1416,6 +1514,7 @@ interface UpdateChartResponse {
   success: boolean;
   data?: {
     elementId: string;
+    chartType: ChartType;       // 更新后的 chartType
     updatedFields: string[];    // 实际生效的字段列表（如 ["title","series"]）
   };
   error?: ErrorResponse;
@@ -1427,10 +1526,10 @@ interface UpdateChartResponse {
 
 | 错误码 | 说明 |
 |--------|------|
-| 4001 | `MISSING_PARAM` - 缺少 elementId |
-| 4002 | `INVALID_PARAM` - chartType 取值不在 ChartType 枚举内 |
+| 4001 | `MISSING_PARAM` - 缺少 `elementId` 或 `chart.chartType` |
+| 4002 | `INVALID_PARAM` - `chartType` 不在枚举内，或字段形状与所选 variant 不匹配 |
 | 3010 | `ELEMENT_NOT_FOUND` - 指定 elementId 不存在或不是图表元素 |
-| 3015 | `INVALID_CHART_DATA` - 替换后 series.values 长度与 categories 不一致 |
+| 3015 | `INVALID_CHART_DATA` - 跨 variant 切换未补齐 `series`；或更新后 categorical 维度不一致 / scatter `points` 含非法值 |
 | 3001 | `DOCUMENT_NOT_FOUND` - 文档未找到 |
 | 3003 | `DOCUMENT_READ_ONLY` - 文档为只读模式 |
 | 3004 | `OPERATION_FAILED` - OOXML 写入失败 |


### PR DESCRIPTION
## Summary

PR #4 把 Scatter 和分类型图表塞进同一个 `ChartData` shape，AI 用 Scatter 时只能把 X 坐标 stringify 进 `categories` —— 这个约束是**隐式的**，不出现在 LLM 调用 MCP 工具时看到的 JSON Schema 里。本 PR 把 `ChartData` 改造成 discriminated union，让 `chartType` 直接驱动 schema 形状，约束变成 schema 层显式表达。

## Changes

### data-structures.md（图表相关 段）

- `ChartType` 拆分：`CategoricalChartType`（9 个）+ `ScatterChartType`（`"Scatter"`），`ChartType = CategoricalChartType | ScatterChartType` 仍是入口别名
- `ChartSeries` 拆为 `CategoricalSeries`（`values: number[]`）+ `ScatterSeries`（`points: ScatterPoint[]`）
- 新增 `ScatterPoint { x, y }`
- `ChartData` 重写为 `CategoricalChartData | ScatterChartData` discriminated union
- 加入 「为什么用 discriminated union」 admonition + JSON Schema 落地建议（`oneOf + discriminator`）
- 数据维度校验拆为两条（categorical 维度 / scatter 非空 + 有限数）

### events-ppt.md（3 个 chart 事件）

- `ppt:insert:chart`: admonition 数据结构链接同步；新增 「schema 形状由 chartType 决定」 提示；2 个请求示例（柱形图 + 散点图）；响应去掉 `categoryCount`（与 variant 解耦），需明细数据请调用 `get:chart`
- `ppt:get:chart`: 响应说明强调 `chart` 是 union，调用方按 `chartType` 分支处理
- `ppt:update:chart`: `chart` 字段改为 `ChartUpdate = CategoricalChartUpdate | ScatterChartUpdate`，`chartType` 作为必需 discriminator；`title?: string | null` 支持删除标题；新增 「跨 variant 切换需补齐数据」 admonition；2 个示例（仅改标题 / Column→Scatter 跨 variant 切换）
- `3015 INVALID_CHART_DATA` 错误场景扩展：覆盖 categorical 维度 / scatter `points` 非法 / 跨 variant 未补 series 三类

### changelog.md（[Unreleased] 段就地修订）

- 表格条目按 union 形态重写
- 设计取舍新增 「discriminated union」 + 「update 强制 chartType」 两段
- PR 链接补 `#4 → #5` 演进路径

## 设计取舍

- **`update:chart` 强制 `chartType`**：让 schema 限定 variant；AI 调用前先 `get:chart` 读取并回填，比让所有字段都 optional 更可靠
- **同一 [Unreleased] 周期内重构**：沿用 Word PR #1 在 `[Unreleased]` 里就地修订的项目惯例，未对外发版的旧 shape 不留化石条目
- **响应 `categoryCount` 移除**：与 variant 解耦；详细数据通过 `get:chart` 拉取

## 兼容性

- 所有变更在 [Unreleased] 内、PR #4 尚未发版，无在线消费方
- office4ai issue [#9](https://github.com/JIAQIA/office4ai/issues/9) 实装尚未开始，DTO 直接按本 PR 形态做即可

## Test plan

- [x] `uv run mkdocs build` 无新增 warning
- [ ] Reviewer 评审 discriminated union 落地建议（`oneOf + discriminator`）是否覆盖主流 JSON Schema 工具链
- [ ] Reviewer 评审 `update:chart` 强制 `chartType` 是否给 AI 调用造成不必要负担
- [ ] 文档预览（mkdocs serve）人工核对 chart 事件锚点 + 跨 variant 切换示例

## Refs

- Issue: #2
- 演进：#4（首版 categorical-only）→ 本 PR
- 消费方：[office4ai#9](https://github.com/JIAQIA/office4ai/issues/9)（按本 PR shape 实装）
- Milestone: PPT Chart Capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)