### PR TITLE
feat(ppt): #9 /ppt 文字格式能力补齐 + 字体抽象统一收敛（文本框 + 表格复用 PptFont）

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -43,6 +43,29 @@
 
 **范围边界（不含）**：段落级排版（行距 / 缩进 / 段间距）、字间距、超链接写入、竖排——office.js PowerPoint API 无原生支持，走 OOXML 路径另案；bullet 自定义字符 / 字体 / 颜色——office.js 不提供，协议不设字段。Add-In 侧既有实现缺口（`insert:text` 字体哑参数 / `update:textBox` `fillColor` 未透传 / underline 退化实现）由 office-editor4ai 单独立项修复，非协议变更。
 
+### /ppt 表格单元格字体收敛（`ppt:update:tableFormat`，Draft 破坏性收敛）
+
+延续上条的字体抽象统一：`ppt:update:tableFormat` 的 `cellFormats` / `rowFormats` / `columnFormats` 原本平铺 `fontSize`/`fontColor`/`bold`/`italic`，属同类散堆，现**收敛复用同一 [`PptFont`](../specification/data-structures.md#pptfont)**（12 属性全量可用，含 17 值下划线 / 删除线 / 上下标 / 大写），使全 `/ppt` 字体抽象一致。
+
+**可行性来源**：经 `/cross-ask office-editor4ai` 复核——`TableCell.font` 即标准 `ShapeFont`，`PptFont` 12 属性零丢失、无需另立精简结构。
+
+| 变更类型 | 位置 | 说明 |
+|----------|------|------|
+| **移除 + 收敛（Draft 破坏性）** | `ppt:update:tableFormat` | 三级 formats 的扁平 `fontSize`/`fontColor`/`bold`/`italic` **删除**，统一改用 `font?: PptFont`（`fontColor`→`color` 语义一致、安全改名） |
+| 新增（行/列级字体，方案 A） | `rowFormats[]` / `columnFormats[]` | 由「仅 `fontSize`」升级为完整 `font?: PptFont`，消除「行/列只能设字号」的割裂；`height`/`width` 保留为行/列 native |
+| 新增（数据结构） | `data-structures.md` | `ParagraphHorizontalAlignment`（7 值）、`TextVerticalAlignment`（6 值）枚举，替换原 `string` 并放开到 office.js 全枚举 |
+| 复用（新增错误码引用） | `ppt:update:tableFormat` | 门槛不满足 → [`3016`](../specification/error-handling.md#api_not_supported-3016)；越界 / 合并单元格非左上格 / 枚举非法 → [`4002`](../specification/error-handling.md) |
+
+**版本门槛（与文本框不同，单列）**：表格单元格字体 / 对齐 / 行高列宽**统一 1.9**——因 `TableCell.font` 访问器门槛为 1.9，把复用的 `PptFont` 底层 1.4/1.8 属性整体抬平；降级判定为单一 `isSetSupported("PowerPointApi","1.9")`，不按属性取 max。现工具已依赖 `cell.font`（1.9），扩到 12 属性**零额外版本成本**。
+
+**单元格无 run 级**：office.js 未暴露单元格内字符区间寻址，`font` 作用于整格，不支持 `runs`。
+
+**行/列级即逐格扇出**：office.js 无「整行/整列字体」原生 API，`rowFormats`/`columnFormats` 的 `font`/`backgroundColor` 均为逐格施加到该行/列每个单元格的糖；命中同一格优先级 `cellFormats` > `columnFormats` > `rowFormats`（沿用既有 `backgroundColor` 口径）。
+
+**全或无（含合并单元格）**：应用前前置校验所有目标格（含行/列展开），任一越界或命中合并单元格非左上格（`getCellOrNullObject` 空对象）→ 整请求 `4002` 失败、不写入任何格；与文本框「全或无」口径一致（纠正现工具「跳过非法格」的部分成功语义，由 office-editor4ai 跟进实现）。
+
+**兼容性**：移除三级 formats 的扁平字体字段对 `/ppt` 为破坏性变更；因 `/ppt` 为 Draft 可接受。目标 `0.4.0`。
+
 ---
 
 ## [0.3.0] - 2026-05-26

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -9,18 +9,18 @@
 
 ## [Unreleased]
 
-### 新增（/ppt 文字格式能力补齐 — MINOR，向后兼容）
+### /ppt 文字格式能力补齐 + 字段收敛（Draft 破坏性收敛）
 
-为 `/ppt` 文字工具补齐一批 office.js 原生支持的常规文字格式能力：run 级局部格式、删除线/双删除线、上标/下标、全大写/小型大写、多下划线样式、项目符号、插入即带字体。字段结构收敛为 `font` 子对象，整框级与 run 级复用。
+为 `/ppt` 文字工具补齐一批 office.js 原生支持的常规文字格式能力：run 级局部格式、删除线/双删除线、上标/下标、全大写/小型大写、多下划线样式、项目符号、插入即带字体。**字段结构统一收敛为 `font` 子对象**：`insert:text` / `update:textBox` 原有的扁平 `fontSize`/`fontName`/`color`/`bold`/`italic` **直接移除**（不保留 Deprecated 别名），改由 `font.*` 承载——整框级与 run 级复用同一 `PptFont`。因 `/ppt` 为 Draft，允许此破坏性收敛，避免协议表面长期背负散堆的扁平字段。
 
 **可行性来源**：office4ai#45 提出；经 `/cross-ask office-editor4ai`（Add-In / office.js）逐项复核可落地，并**纠正了 issue 的版本假设**（见下「requirement set 分档」）——无 P0，无需 Server 离线回退。
 
 | 变更类型 | 位置 | 说明 |
 |----------|------|------|
 | 新增（数据结构） | `data-structures.md` | `PptFont`（整框级 / run 级共用的字体子对象，12 属性含删除线/上下标/大写/下划线）、`ShapeFontUnderlineStyle`（17 值 PascalCase 枚举）、`PptTextRun`（`{start,length,font}` run 级寻址）、`PptParagraphStyle`（`{start,length,bulletFormat}` 段落级寻址）、`BulletFormat`（`visible`/`type`/`style`，**无 `character`**）、`BulletType` 枚举 |
-| 变更（事件字段） | `events-ppt.md` `ppt:update:textBox` | `TextBoxUpdates` 新增 `font` / `runs[]` / `paragraphs[]`；应用顺序 `font`→`runs`→`paragraphs`（后者覆盖重叠区间） |
+| 变更（事件字段） | `events-ppt.md` `ppt:update:textBox` | `TextBoxUpdates` 新增 `font` / `runs[]` / `paragraphs[]`；应用顺序 `text`→`font`→`runs`→`paragraphs`（内容替换在先，区间寻址对齐替换后最终文本；后者覆盖重叠区间） |
 | 变更（事件字段） | `events-ppt.md` `ppt:insert:text` | `TextInsertOptions` 新增 `font`（插入即带字体，语义等价「插入 + 格式」复合操作） |
-| Deprecated（向后兼容保留） | `events-ppt.md` | `TextBoxUpdates` 与 `TextInsertOptions` 的扁平 `fontSize`/`fontName`/`color`/`bold`/`italic` 标记 ⚠️ Deprecated，语义等价 `font.*`；同时提供时 `font.*` 优先 |
+| **移除（Draft 破坏性收敛）** | `events-ppt.md` | `TextBoxUpdates` 与 `TextInsertOptions` 的扁平 `fontSize`/`fontName`/`color`/`bold`/`italic` **删除**，统一改用 `font.*`；`/ppt` 为 Draft，不保留 Deprecated 别名 |
 | 复用（无新错误码） | `events-ppt.md` / `error-handling.md` | 区间越界 / 枚举非法复用 [`4002 INVALID_PARAM`](../specification/error-handling.md)；requirement set 不满足复用 [`3016 API_NOT_SUPPORTED`](../specification/error-handling.md#api_not_supported-3016)（`details.requiredApiSet` 标注版本） |
 
 **requirement set 分档（经 Add-In 真机复核，纠正 issue 假设）**：
@@ -33,11 +33,13 @@
 
 **降级语义**：宿主不满足**本次请求所含属性**的最高 requirement set 时，事件按**反应式 `3016` 整体失败（全或无）**，与现有 `/ppt` 事件（`insert:chart` / `slidesOoxml`）一致；调用方靠「只发受支持的属性」控制粒度。不引入「部分成功」响应语义。
 
-**字符区间口径**：`runs` / `paragraphs` 的 `start` / `length` 以 **UTF-16 code unit** 计，含段落分隔 `\r` 与软换行 `\v`；越界 → `4002`。
+**字符区间口径**：`runs` / `paragraphs` 的 `start` / `length` 以 **UTF-16 code unit** 计，含段落分隔 `\r` 与软换行 `\v`；与 `updates.text` 并存时**先替换内容、offset 对齐替换后的最终文本**；越界 → `4002`。
 
 **跨命名空间说明**：PPT `ShapeFontUnderlineStyle`（17 值 PascalCase，对齐 office.js PowerPoint 枚举、零映射）与 `/word` `UnderlineStyle`（7 值小写、映射 Word.js）**有意不同**，服务不同宿主 API，不复用。
 
-**兼容性**：纯新增可选字段 + 扁平字段 Deprecated 别名，**向后兼容**；`/ppt` 为 Draft。已部署 AddIn 忽略未知字段即可。属 v0.x 阶段的 MINOR 级变更（目标 `0.4.0`）。
+**枚举承载分档**：宿主枚举按**集合大小与稳定性**择一承载——小而封闭者就地全枚举（`ShapeFontUnderlineStyle` 17 值，可校验）；大而易变者直通 `string`（bullet `style` 40+ 值，由宿主校验、非法值 → `4002`）。二者同为"零映射对齐宿主"，形态分档是一致原则而非遗漏。
+
+**兼容性**：新增可选字段属向后兼容；但**移除扁平 `fontSize`/`fontName`/`color`/`bold`/`italic` 对 `/ppt` 是破坏性变更**——调用方须改用 `font.*`。因 `/ppt` 为 Draft（无稳定性承诺），此收敛可接受。已部署 AddIn 忽略未知字段即可。属 v0.x 阶段变更（目标 `0.4.0`）。
 
 **范围边界（不含）**：段落级排版（行距 / 缩进 / 段间距）、字间距、超链接写入、竖排——office.js PowerPoint API 无原生支持，走 OOXML 路径另案；bullet 自定义字符 / 字体 / 颜色——office.js 不提供，协议不设字段。Add-In 侧既有实现缺口（`insert:text` 字体哑参数 / `update:textBox` `fillColor` 未透传 / underline 退化实现）由 office-editor4ai 单独立项修复，非协议变更。
 

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -9,7 +9,37 @@
 
 ## [Unreleased]
 
-_暂无未发布变更。_
+### 新增（/ppt 文字格式能力补齐 — MINOR，向后兼容）
+
+为 `/ppt` 文字工具补齐一批 office.js 原生支持的常规文字格式能力：run 级局部格式、删除线/双删除线、上标/下标、全大写/小型大写、多下划线样式、项目符号、插入即带字体。字段结构收敛为 `font` 子对象，整框级与 run 级复用。
+
+**可行性来源**：office4ai#45 提出；经 `/cross-ask office-editor4ai`（Add-In / office.js）逐项复核可落地，并**纠正了 issue 的版本假设**（见下「requirement set 分档」）——无 P0，无需 Server 离线回退。
+
+| 变更类型 | 位置 | 说明 |
+|----------|------|------|
+| 新增（数据结构） | `data-structures.md` | `PptFont`（整框级 / run 级共用的字体子对象，12 属性含删除线/上下标/大写/下划线）、`ShapeFontUnderlineStyle`（17 值 PascalCase 枚举）、`PptTextRun`（`{start,length,font}` run 级寻址）、`PptParagraphStyle`（`{start,length,bulletFormat}` 段落级寻址）、`BulletFormat`（`visible`/`type`/`style`，**无 `character`**）、`BulletType` 枚举 |
+| 变更（事件字段） | `events-ppt.md` `ppt:update:textBox` | `TextBoxUpdates` 新增 `font` / `runs[]` / `paragraphs[]`；应用顺序 `font`→`runs`→`paragraphs`（后者覆盖重叠区间） |
+| 变更（事件字段） | `events-ppt.md` `ppt:insert:text` | `TextInsertOptions` 新增 `font`（插入即带字体，语义等价「插入 + 格式」复合操作） |
+| Deprecated（向后兼容保留） | `events-ppt.md` | `TextBoxUpdates` 与 `TextInsertOptions` 的扁平 `fontSize`/`fontName`/`color`/`bold`/`italic` 标记 ⚠️ Deprecated，语义等价 `font.*`；同时提供时 `font.*` 优先 |
+| 复用（无新错误码） | `events-ppt.md` / `error-handling.md` | 区间越界 / 枚举非法复用 [`4002 INVALID_PARAM`](../specification/error-handling.md)；requirement set 不满足复用 [`3016 API_NOT_SUPPORTED`](../specification/error-handling.md#api_not_supported-3016)（`details.requiredApiSet` 标注版本） |
+
+**requirement set 分档（经 Add-In 真机复核，纠正 issue 假设）**：
+
+| 能力 | 最低 PowerPointApi | 备注 |
+|------|-------------------|------|
+| 下划线全枚举、run 级寻址（`getSubstring`）、run 级 bold/italic/size/name/color、bullet `visible` | **1.4** | issue 曾误标下划线/大写/删除线为 1.4、getSubstring 为 1.5 |
+| 删除线 / 双删除线、上标 / 下标、全大写 / 小型大写（含其 run 级） | **1.8** | issue 误标为 1.4；整批有效门槛 = 1.8 |
+| bullet `type` / `style`（编号列表） | **1.10** | `visible` 仅需 1.4 |
+
+**降级语义**：宿主不满足**本次请求所含属性**的最高 requirement set 时，事件按**反应式 `3016` 整体失败（全或无）**，与现有 `/ppt` 事件（`insert:chart` / `slidesOoxml`）一致；调用方靠「只发受支持的属性」控制粒度。不引入「部分成功」响应语义。
+
+**字符区间口径**：`runs` / `paragraphs` 的 `start` / `length` 以 **UTF-16 code unit** 计，含段落分隔 `\r` 与软换行 `\v`；越界 → `4002`。
+
+**跨命名空间说明**：PPT `ShapeFontUnderlineStyle`（17 值 PascalCase，对齐 office.js PowerPoint 枚举、零映射）与 `/word` `UnderlineStyle`（7 值小写、映射 Word.js）**有意不同**，服务不同宿主 API，不复用。
+
+**兼容性**：纯新增可选字段 + 扁平字段 Deprecated 别名，**向后兼容**；`/ppt` 为 Draft。已部署 AddIn 忽略未知字段即可。属 v0.x 阶段的 MINOR 级变更（目标 `0.4.0`）。
+
+**范围边界（不含）**：段落级排版（行距 / 缩进 / 段间距）、字间距、超链接写入、竖排——office.js PowerPoint API 无原生支持，走 OOXML 路径另案；bullet 自定义字符 / 字体 / 颜色——office.js 不提供，协议不设字段。Add-In 侧既有实现缺口（`insert:text` 字体哑参数 / `update:textBox` `fillColor` 未透传 / underline 退化实现）由 office-editor4ai 单独立项修复，非协议变更。
 
 ---
 

--- a/docs/specification/data-structures.md
+++ b/docs/specification/data-structures.md
@@ -209,8 +209,9 @@ interface PptParagraphStyle {
 
 !!! important "字符区间口径（start / length）"
     - `start` 为 0 基字符下标、`length` 为字符数，二者均以 **UTF-16 code unit** 计（= JavaScript 字符串语义；emoji / 代理对算 2 个单位）。
-    - 计数对齐文本框 `text` 的完整内容，**含段落分隔符 `\r` 与软换行 `\v`**（这些字符占下标）。双端须以同一口径计算 offset。
-    - 越界（`start < 0` 或 `start + length > text.length`）按 [`4002 INVALID_PARAM`](error-handling.md) 处理。
+    - 计数对齐文本框的**最终文本**完整内容，**含段落分隔符 `\r` 与软换行 `\v`**（这些字符占下标）。双端须以同一口径计算 offset。
+    - **与 `text` 替换并存时的口径**：当同一次 `ppt:update:textBox` 请求既提供 `updates.text`（整框内容替换）又提供 `runs` / `paragraphs` 时，**内容替换先于格式应用**，`start` / `length` 一律对齐**替换后的新文本**（不是替换前的旧内容）；未提供 `updates.text` 时则对齐文本框现有内容。因此 `text.length` 指该次生效的最终文本长度。
+    - 越界（`start < 0` 或 `start + length > text.length`，此处 `text.length` 即上条所指最终文本长度）按 [`4002 INVALID_PARAM`](error-handling.md) 处理。
     - `runs` / `paragraphs` 在同一次请求内按数组顺序应用，后者覆盖先者的重叠区间。
 
 ### BulletFormat
@@ -235,6 +236,14 @@ type BulletType = "None" | "Numbered" | "Unnumbered" | "Unsupported";
 
 !!! warning "office.js 硬限制"
     `bulletFormat` **没有** `character`（自定义符号字符）、字体、颜色属性——协议不提供这些字段。`type` / `style`（真正的编号列表）需 PowerPointApi **1.10**；`visible`（显示 / 隐藏）仅需 **1.4**。
+
+!!! info "为何 `style` 用 `string` 而 `underline` 用完整枚举（有意的不对称）"
+    协议对宿主枚举有两种收敛策略，按**集合大小与稳定性**择一，非随意：
+
+    - **小而封闭的集合 → 就地全枚举**（如 [`ShapeFontUnderlineStyle`](#shapefontunderlinestyle) 的 17 值）：值少、稳定、可在协议层做类型校验与提示，收益高、维护成本低。
+    - **大而易变的宿主枚举 → 直通 `string`**（`style` 对应 office.js bullet 样式，40+ 值且随宿主版本增补）：就地全枚举会让协议文档与一个庞大且演进中的宿主枚举强耦合、易过时。故 `style` 定义为**对齐 office.js 样式字面量的直通字符串**，由宿主在应用时校验；非法值按 [`4002 INVALID_PARAM`](error-handling.md) 处理，与 `underline` 非枚举值的失败口径一致。
+
+    即：**两者都是"零映射对齐宿主枚举"，只是承载形态按集合规模分档**——这是一致的抽象原则，不是遗漏。
 
 ---
 

--- a/docs/specification/data-structures.md
+++ b/docs/specification/data-structures.md
@@ -167,6 +167,8 @@ interface PptFont {
 !!! note "requirement set 与降级（全或无）"
     每个属性标注其最低 PowerPointApi requirement set。当前宿主不满足**本次请求所含属性**的最高 requirement set 时，承载该 `PptFont` 的事件按**反应式** [`3016 API_NOT_SUPPORTED`](error-handling.md#api_not_supported-3016) **整体失败（全或无，不做部分应用）**，错误 `details.requiredApiSet` 标注所需版本。调用方据此降级——例如仅发送 1.4 属性以适配低版本宿主。此处理与握手无关：[版本握手 ≠ 运行时能力](conventions.md)，能力不足在操作期反应式处理。
 
+    **上表 1.4 / 1.8 分档为文本框（`textRange.font`）语境。** `PptFont` 复用于 [`ppt:update:tableFormat`](events-ppt.md#pptupdatetableformat) 的表格单元格时，因 office.js `TableCell.font` 访问器门槛为 **1.9**，会把底层属性整体**抬平到 1.9**（单一门槛，无需按属性取 max）；且单元格**无 run 级**（office.js 未暴露单元格内字符区间寻址），`PptFont` 仅作用于整格。详见该事件的版本门槛说明。
+
 ### ShapeFontUnderlineStyle
 
 PPT 下划线样式枚举（17 值，PowerPointApi 1.4）。线缆值即 office.js `ShapeFontUnderlineStyle` 枚举字面量，双端零映射。
@@ -244,6 +246,26 @@ type BulletType = "None" | "Numbered" | "Unnumbered" | "Unsupported";
     - **大而易变的宿主枚举 → 直通 `string`**（`style` 对应 office.js bullet 样式，40+ 值且随宿主版本增补）：就地全枚举会让协议文档与一个庞大且演进中的宿主枚举强耦合、易过时。故 `style` 定义为**对齐 office.js 样式字面量的直通字符串**，由宿主在应用时校验；非法值按 [`4002 INVALID_PARAM`](error-handling.md) 处理，与 `underline` 非枚举值的失败口径一致。
 
     即：**两者都是"零映射对齐宿主枚举"，只是承载形态按集合规模分档**——这是一致的抽象原则，不是遗漏。
+
+### ParagraphHorizontalAlignment
+
+段落 / 表格单元格水平对齐枚举（7 值，PowerPointApi 1.9）。线缆值即 office.js `ParagraphHorizontalAlignment` 枚举字面量，双端零映射。
+
+```typescript
+type ParagraphHorizontalAlignment =
+  | "Left" | "Center" | "Right" | "Justify"
+  | "JustifyLow" | "Distributed" | "ThaiDistributed";
+```
+
+### TextVerticalAlignment
+
+文本 / 表格单元格垂直对齐枚举（6 值，PowerPointApi 1.9）。线缆值即 office.js `TextVerticalAlignment` 枚举字面量，双端零映射。
+
+```typescript
+type TextVerticalAlignment =
+  | "Top" | "Middle" | "Bottom"
+  | "TopCentered" | "MiddleCentered" | "BottomCentered";
+```
 
 ---
 

--- a/docs/specification/data-structures.md
+++ b/docs/specification/data-structures.md
@@ -434,7 +434,7 @@ interface CellFormat {
 !!! note "单元格内边距"
     Word JavaScript API 的单元格内边距是**表级 API**（`Word.Table.setCellPadding`），无法逐单元格设置。如需调整内边距，请通过 `word:update:tableFormat.styleOptions.cellPadding` 在表级配置。
 
-> 该结构当前仅 `/word` 命名空间引用；`/ppt` 已有的 `ppt:update:tableFormat` 后续如需统一字段命名，可平滑迁移到本结构。
+> 该结构仅 `/word` 命名空间引用（对齐 Word.js：[`UnderlineStyle`](#underlinestyle) 7 值小写、`Word.Alignment` 的 `Centered` / `Justified`）。`/ppt` 的 [`ppt:update:tableFormat`](events-ppt.md#pptupdatetableformat) **有意不复用本结构**，改用 [`PptFont`](#pptfont) + [`ParagraphHorizontalAlignment`](#paragraphhorizontalalignment) / [`TextVerticalAlignment`](#textverticalalignment)（对齐 office.js PowerPoint、17 值 PascalCase 下划线、`Center` / `Justify`）——与 underline 枚举同理，服务不同宿主 API、零映射，跨命名空间不复用。
 
 ---
 

--- a/docs/specification/data-structures.md
+++ b/docs/specification/data-structures.md
@@ -124,6 +124,120 @@ type UnderlineStyle =
 
 ---
 
+## PPT 文本格式（/ppt）
+
+> 以下结构服务于 [`ppt:update:textBox`](events-ppt.md#pptupdatetextbox) 与 [`ppt:insert:text`](events-ppt.md#pptinserttext)。字体属性统一收敛到 `PptFont`，**整框级与 run 级复用同一结构**。每个属性标注其最低 PowerPointApi requirement set；宿主不满足时按事件定义走**反应式** [`3016 API_NOT_SUPPORTED`](error-handling.md#api_not_supported-3016) 处理。
+
+### PptFont
+
+PPT 文字字体格式。整框级（`TextBoxUpdates.font` / `TextInsertOptions.font`）与 run 级（`PptTextRun.font`）共用本结构。所有字段可选，未提供的属性保持原样。
+
+```typescript
+interface PptFont {
+  size?: number;                       // 字号（磅）           [1.4]
+  name?: string;                       // 字体名称             [1.4]
+  color?: string;                      // 文字颜色（十六进制） [1.4]
+  bold?: boolean;                      // 粗体                 [1.4]
+  italic?: boolean;                    // 斜体                 [1.4]
+  underline?: ShapeFontUnderlineStyle; // 下划线样式           [1.4]
+  strikethrough?: boolean;             // 删除线               [1.8]
+  doubleStrikethrough?: boolean;       // 双删除线             [1.8]
+  superscript?: boolean;               // 上标                 [1.8]
+  subscript?: boolean;                 // 下标                 [1.8]
+  allCaps?: boolean;                   // 全大写               [1.8]
+  smallCaps?: boolean;                 // 小型大写             [1.8]
+}
+```
+
+| 字段 | 类型 | requirement set | 说明 |
+|------|------|-----------------|------|
+| `size` | number | 1.4 | 字号（磅） |
+| `name` | string | 1.4 | 字体名称 |
+| `color` | string | 1.4 | 文字颜色（十六进制，如 `#FF0000`） |
+| `bold` | boolean | 1.4 | 粗体 |
+| `italic` | boolean | 1.4 | 斜体 |
+| `underline` | ShapeFontUnderlineStyle | 1.4 | 下划线样式（17 值枚举，见下） |
+| `strikethrough` | boolean | 1.8 | 删除线 |
+| `doubleStrikethrough` | boolean | 1.8 | 双删除线 |
+| `superscript` | boolean | 1.8 | 上标 |
+| `subscript` | boolean | 1.8 | 下标 |
+| `allCaps` | boolean | 1.8 | 全大写 |
+| `smallCaps` | boolean | 1.8 | 小型大写 |
+
+!!! note "requirement set 与降级（全或无）"
+    每个属性标注其最低 PowerPointApi requirement set。当前宿主不满足**本次请求所含属性**的最高 requirement set 时，承载该 `PptFont` 的事件按**反应式** [`3016 API_NOT_SUPPORTED`](error-handling.md#api_not_supported-3016) **整体失败（全或无，不做部分应用）**，错误 `details.requiredApiSet` 标注所需版本。调用方据此降级——例如仅发送 1.4 属性以适配低版本宿主。此处理与握手无关：[版本握手 ≠ 运行时能力](conventions.md)，能力不足在操作期反应式处理。
+
+### ShapeFontUnderlineStyle
+
+PPT 下划线样式枚举（17 值，PowerPointApi 1.4）。线缆值即 office.js `ShapeFontUnderlineStyle` 枚举字面量，双端零映射。
+
+```typescript
+type ShapeFontUnderlineStyle =
+  | "None" | "Single" | "Double" | "Heavy"
+  | "Dotted" | "DottedHeavy"
+  | "Dash" | "DashHeavy" | "DashLong" | "DashLongHeavy"
+  | "DotDash" | "DotDashHeavy" | "DotDotDash" | "DotDotDashHeavy"
+  | "Wavy" | "WavyHeavy" | "WavyDouble";
+```
+
+!!! info "与 Word 的 UnderlineStyle 有意不同"
+    `/word` 的 [`UnderlineStyle`](#underlinestyle) 是 7 值小写（`single` / `double` / …），映射 Word.js；PPT 的 `ShapeFontUnderlineStyle` 是 17 值 PascalCase，直接对齐 office.js PowerPoint 的同名枚举。二者服务不同宿主 API，故**不复用**——这是有意的跨命名空间差异，非命名不一致。
+
+### PptTextRun
+
+run 级局部格式：对文本框内一段字符区间单独设置字体。
+
+```typescript
+interface PptTextRun {
+  start: number;    // 区间起始字符下标（0 基，UTF-16 code unit）
+  length: number;   // 区间字符数（UTF-16 code unit）
+  font: PptFont;    // 应用到该区间的字体格式
+}
+```
+
+### PptParagraphStyle
+
+段落级格式（当前仅项目符号）。同样以字符区间寻址：区间**接触到的段落**整体应用。
+
+```typescript
+interface PptParagraphStyle {
+  start: number;               // 区间起始字符下标（0 基，UTF-16 code unit）
+  length: number;              // 区间字符数（UTF-16 code unit）
+  bulletFormat: BulletFormat;  // 应用到区间所在段落的项目符号格式
+}
+```
+
+!!! important "字符区间口径（start / length）"
+    - `start` 为 0 基字符下标、`length` 为字符数，二者均以 **UTF-16 code unit** 计（= JavaScript 字符串语义；emoji / 代理对算 2 个单位）。
+    - 计数对齐文本框 `text` 的完整内容，**含段落分隔符 `\r` 与软换行 `\v`**（这些字符占下标）。双端须以同一口径计算 offset。
+    - 越界（`start < 0` 或 `start + length > text.length`）按 [`4002 INVALID_PARAM`](error-handling.md) 处理。
+    - `runs` / `paragraphs` 在同一次请求内按数组顺序应用，后者覆盖先者的重叠区间。
+
+### BulletFormat
+
+项目符号格式。对齐 office.js `paragraphFormat.bulletFormat`，仅含下列可写属性。
+
+```typescript
+interface BulletFormat {
+  visible?: boolean;   // 是否显示项目符号                      [1.4]
+  type?: BulletType;   // 项目符号类型（无/编号/非编号）        [1.10]
+  style?: string;      // 编号 / 符号样式，对齐 office.js 枚举  [1.10]
+}
+
+type BulletType = "None" | "Numbered" | "Unnumbered" | "Unsupported";
+```
+
+| 字段 | 类型 | requirement set | 说明 |
+|------|------|-----------------|------|
+| `visible` | boolean | 1.4 | 显示 / 隐藏项目符号 |
+| `type` | BulletType | 1.10 | 无 / 编号 / 非编号列表 |
+| `style` | string | 1.10 | 具体编号或符号样式，取值对齐 office.js bullet 样式枚举（如 `ArabicNumeralPeriod` / `RomanUppercasePeriod` / `SimplifiedChinesePeriod` 等 40+ 值） |
+
+!!! warning "office.js 硬限制"
+    `bulletFormat` **没有** `character`（自定义符号字符）、字体、颜色属性——协议不提供这些字段。`type` / `style`（真正的编号列表）需 PowerPointApi **1.10**；`visible`（显示 / 隐藏）仅需 **1.4**。
+
+---
+
 ## 样式相关
 
 ### StyleInfo

--- a/docs/specification/events-ppt.md
+++ b/docs/specification/events-ppt.md
@@ -802,12 +802,18 @@ interface TextInsertOptions {
   top?: number;              // Y 坐标（磅）
   width?: number;            // 文本框宽度（磅），默认 300
   height?: number;           // 文本框高度（磅），默认 100
-  fontSize?: number;         // 字号
-  fontName?: string;         // 字体名称
-  color?: string;            // 文字颜色（十六进制，如 "#FF0000"）
-  fillColor?: string;        // 填充颜色（十六进制）
+  fillColor?: string;        // 文本框填充色（十六进制）
+  font?: PptFont;            // 插入文本的字体格式，见 data-structures.md#pptfont
+
+  // —— 以下扁平字段自 0.3.0 起 ⚠️ Deprecated：等价写入 font.*，保留向后兼容 ——
+  fontSize?: number;         // ⚠️ Deprecated → font.size
+  fontName?: string;         // ⚠️ Deprecated → font.name
+  color?: string;            // ⚠️ Deprecated → font.color
 }
 ```
+
+!!! note "插入即带字体格式"
+    `options.font`（`PptFont`）在插入文本框的同时应用字体格式，语义等价「插入 + 格式」的一次性复合操作。扁平字段 `fontSize` / `fontName` / `color` 已 **Deprecated**，等价 `font.*`；同时提供时 `font.*` 优先。各属性的 requirement set 与**反应式 3016 全或无**降级同 [`PptFont`](data-structures.md#pptfont)。
 
 **请求参数说明**:
 
@@ -819,10 +825,11 @@ interface TextInsertOptions {
 | `top` | number | ❌ | - | Y 坐标（磅），未指定时使用默认位置 |
 | `width` | number | ❌ | 300 | 文本框宽度（磅） |
 | `height` | number | ❌ | 100 | 文本框高度（磅） |
-| `fontSize` | number | ❌ | - | 字号 |
-| `fontName` | string | ❌ | - | 字体名称 |
-| `color` | string | ❌ | - | 文字颜色（十六进制） |
-| `fillColor` | string | ❌ | - | 文本框填充颜色（十六进制） |
+| `fillColor` | string | ❌ | - | 文本框填充色（十六进制） |
+| `font` | [`PptFont`](data-structures.md#pptfont) | ❌ | - | 插入文本的字体格式 |
+| `fontSize` | number | ❌ | - | ⚠️ Deprecated → `font.size` |
+| `fontName` | string | ❌ | - | ⚠️ Deprecated → `font.name` |
+| `color` | string | ❌ | - | ⚠️ Deprecated → `font.color` |
 
 **请求示例**:
 
@@ -886,7 +893,8 @@ interface InsertTextResponse {
 | 错误码 | 说明 |
 |--------|------|
 | 4001 | `MISSING_PARAM` - 缺少 text 参数 |
-| 4002 | `INVALID_PARAM` - slideIndex 超出范围 |
+| 4002 | `INVALID_PARAM` - slideIndex 超出范围，或 `font.underline` 不在枚举内 |
+| 3016 | `API_NOT_SUPPORTED` - `font` 所含属性所需 PowerPointApi requirement set（删除线/上下标/大写=1.8）在当前宿主不满足；`details.requiredApiSet` 标注所需版本 |
 | 3001 | `DOCUMENT_NOT_FOUND` - 文档未找到 |
 | 3000 | `OFFICE_API_ERROR` - Office API 调用错误 |
 
@@ -1579,34 +1587,49 @@ interface UpdateTextBoxRequest {
 }
 
 interface TextBoxUpdates {
-  text?: string;             // 新文本内容
-  fontSize?: number;         // 字号
-  fontName?: string;         // 字体名称
-  color?: string;            // 文字颜色（十六进制，如 "#FF0000"）
-  fillColor?: string;        // 填充颜色（十六进制）
-  bold?: boolean;            // 粗体
-  italic?: boolean;          // 斜体
+  text?: string;                     // 新文本内容（整框）
+  fillColor?: string;                // 文本框填充色（十六进制，框级）
+  font?: PptFont;                    // 整框级字体格式（铺底），见 data-structures.md#pptfont
+  runs?: PptTextRun[];               // run 级局部格式（区间覆盖，后者胜）
+  paragraphs?: PptParagraphStyle[];  // 段落级格式（项目符号 bulletFormat）
+
+  // —— 以下扁平字段自 0.3.0 起 ⚠️ Deprecated：等价写入 font.*，保留向后兼容 ——
+  fontSize?: number;                 // ⚠️ Deprecated → font.size
+  fontName?: string;                 // ⚠️ Deprecated → font.name
+  color?: string;                    // ⚠️ Deprecated → font.color
+  bold?: boolean;                    // ⚠️ Deprecated → font.bold
+  italic?: boolean;                  // ⚠️ Deprecated → font.italic
 }
 ```
+
+!!! note "字段结构：font 子对象 + 区间覆盖"
+    - **整框级**用 `font`（`PptFont`）铺底；**run 级**用 `runs[]`（每段 `{start, length, font}`）覆盖指定字符区间；**段落级** bullet 用 `paragraphs[]`（`{start, length, bulletFormat}`）。
+    - **应用顺序**：`font`（整框铺底）→ `runs`（按数组序覆盖重叠区间）→ `paragraphs`（bullet）。
+    - 扁平字段 `fontSize` / `fontName` / `color` / `bold` / `italic` 为 0.3.0 遗留、**已 Deprecated**，语义等价 `font.*`。同时提供扁平字段与 `font.*` 时 **`font.*` 优先**。
+    - `runs` / `paragraphs` 的 `start` / `length` 口径（UTF-16 code unit、含 `\r` / `\v`、越界 → `4002`）见 [字符区间口径](data-structures.md#pptparagraphstyle)。
+    - 各字体属性的 requirement set 及**反应式 3016 全或无**降级见 [`PptFont`](data-structures.md#pptfont)。
 
 **请求参数说明**:
 
 | 参数 | 类型 | 必需 | 说明 |
 |------|------|------|------|
 | `elementId` | string | ✅ | 要更新的元素 ID（可通过 `ppt:get:slideElements` 获取） |
-| `text` | string | ❌ | 新文本内容 |
-| `fontSize` | number | ❌ | 字号 |
-| `fontName` | string | ❌ | 字体名称 |
-| `color` | string | ❌ | 文字颜色（十六进制） |
-| `fillColor` | string | ❌ | 文本框填充颜色（十六进制） |
-| `bold` | boolean | ❌ | 是否粗体 |
-| `italic` | boolean | ❌ | 是否斜体 |
+| `updates.text` | string | ❌ | 新文本内容（整框） |
+| `updates.fillColor` | string | ❌ | 文本框填充色（十六进制，框级） |
+| `updates.font` | [`PptFont`](data-structures.md#pptfont) | ❌ | 整框级字体格式 |
+| `updates.runs` | [`PptTextRun[]`](data-structures.md#ppttextrun) | ❌ | run 级局部格式（字符区间寻址，可多段） |
+| `updates.paragraphs` | [`PptParagraphStyle[]`](data-structures.md#pptparagraphstyle) | ❌ | 段落级项目符号（字符区间寻址） |
+| `updates.fontSize` | number | ❌ | ⚠️ Deprecated → `font.size` |
+| `updates.fontName` | string | ❌ | ⚠️ Deprecated → `font.name` |
+| `updates.color` | string | ❌ | ⚠️ Deprecated → `font.color` |
+| `updates.bold` | boolean | ❌ | ⚠️ Deprecated → `font.bold` |
+| `updates.italic` | boolean | ❌ | ⚠️ Deprecated → `font.italic` |
 
 !!! note "支持的元素类型"
     仅支持 `TextBox`、`Placeholder`、`GeometricShape` 类型的元素。
     对不支持文本的元素类型将返回错误。
 
-**请求示例**:
+**请求示例（font 子对象 + run 级局部格式 + 段落 bullet）**:
 
 ```json
 {
@@ -1615,9 +1638,14 @@ interface TextBoxUpdates {
   "elementId": "shape-001",
   "updates": {
     "text": "更新后的标题",
-    "fontSize": 28,
-    "bold": true,
-    "color": "#333333"
+    "font": { "size": 28, "bold": true, "color": "#333333", "underline": "WavyHeavy" },
+    "runs": [
+      { "start": 0, "length": 4, "font": { "color": "#C00000", "allCaps": true } },
+      { "start": 10, "length": 6, "font": { "underline": "Dotted", "subscript": true } }
+    ],
+    "paragraphs": [
+      { "start": 0, "length": 20, "bulletFormat": { "visible": true, "type": "Numbered", "style": "ArabicNumeralPeriod" } }
+    ]
   }
 }
 ```
@@ -1676,7 +1704,9 @@ interface UpdateTextBoxResponse {
 | 错误码 | 说明 |
 |--------|------|
 | 4001 | `MISSING_PARAM` - 缺少 elementId |
+| 4002 | `INVALID_PARAM` - `runs` / `paragraphs` 的 `start`/`length` 越界（`start < 0` 或 `start + length > text.length`），或 `underline` / `bulletFormat.type` 不在枚举内 |
 | 3003 | `OPERATION_FAILED` - 元素未找到或元素类型不支持文本编辑 |
+| 3016 | `API_NOT_SUPPORTED` - 本次请求所含字体/项目符号属性所需 PowerPointApi requirement set（删除线/上下标/大写=1.8、bullet type/style=1.10）在当前宿主不满足；`details.requiredApiSet` 标注所需版本，调用方应仅发送受支持的属性或提示用户 |
 | 3001 | `DOCUMENT_NOT_FOUND` - 文档未找到 |
 | 3000 | `OFFICE_API_ERROR` - Office API 调用错误 |
 

--- a/docs/specification/events-ppt.md
+++ b/docs/specification/events-ppt.md
@@ -804,16 +804,11 @@ interface TextInsertOptions {
   height?: number;           // 文本框高度（磅），默认 100
   fillColor?: string;        // 文本框填充色（十六进制）
   font?: PptFont;            // 插入文本的字体格式，见 data-structures.md#pptfont
-
-  // —— 以下扁平字段自 0.3.0 起 ⚠️ Deprecated：等价写入 font.*，保留向后兼容 ——
-  fontSize?: number;         // ⚠️ Deprecated → font.size
-  fontName?: string;         // ⚠️ Deprecated → font.name
-  color?: string;            // ⚠️ Deprecated → font.color
 }
 ```
 
 !!! note "插入即带字体格式"
-    `options.font`（`PptFont`）在插入文本框的同时应用字体格式，语义等价「插入 + 格式」的一次性复合操作。扁平字段 `fontSize` / `fontName` / `color` 已 **Deprecated**，等价 `font.*`；同时提供时 `font.*` 优先。各属性的 requirement set 与**反应式 3016 全或无**降级同 [`PptFont`](data-structures.md#pptfont)。
+    `options.font`（`PptFont`）在插入文本框的同时应用字体格式，语义等价「插入 + 格式」的一次性复合操作。各属性的 requirement set 与**反应式 3016 全或无**降级同 [`PptFont`](data-structures.md#pptfont)。
 
 **请求参数说明**:
 
@@ -827,9 +822,6 @@ interface TextInsertOptions {
 | `height` | number | ❌ | 100 | 文本框高度（磅） |
 | `fillColor` | string | ❌ | - | 文本框填充色（十六进制） |
 | `font` | [`PptFont`](data-structures.md#pptfont) | ❌ | - | 插入文本的字体格式 |
-| `fontSize` | number | ❌ | - | ⚠️ Deprecated → `font.size` |
-| `fontName` | string | ❌ | - | ⚠️ Deprecated → `font.name` |
-| `color` | string | ❌ | - | ⚠️ Deprecated → `font.color` |
 
 **请求示例**:
 
@@ -844,9 +836,7 @@ interface TextInsertOptions {
     "top": 200,
     "width": 400,
     "height": 80,
-    "fontSize": 18,
-    "fontName": "微软雅黑",
-    "color": "#333333"
+    "font": { "size": 18, "name": "微软雅黑", "color": "#333333" }
   }
 }
 ```
@@ -1592,21 +1582,13 @@ interface TextBoxUpdates {
   font?: PptFont;                    // 整框级字体格式（铺底），见 data-structures.md#pptfont
   runs?: PptTextRun[];               // run 级局部格式（区间覆盖，后者胜）
   paragraphs?: PptParagraphStyle[];  // 段落级格式（项目符号 bulletFormat）
-
-  // —— 以下扁平字段自 0.3.0 起 ⚠️ Deprecated：等价写入 font.*，保留向后兼容 ——
-  fontSize?: number;                 // ⚠️ Deprecated → font.size
-  fontName?: string;                 // ⚠️ Deprecated → font.name
-  color?: string;                    // ⚠️ Deprecated → font.color
-  bold?: boolean;                    // ⚠️ Deprecated → font.bold
-  italic?: boolean;                  // ⚠️ Deprecated → font.italic
 }
 ```
 
 !!! note "字段结构：font 子对象 + 区间覆盖"
     - **整框级**用 `font`（`PptFont`）铺底；**run 级**用 `runs[]`（每段 `{start, length, font}`）覆盖指定字符区间；**段落级** bullet 用 `paragraphs[]`（`{start, length, bulletFormat}`）。
-    - **应用顺序**：`font`（整框铺底）→ `runs`（按数组序覆盖重叠区间）→ `paragraphs`（bullet）。
-    - 扁平字段 `fontSize` / `fontName` / `color` / `bold` / `italic` 为 0.3.0 遗留、**已 Deprecated**，语义等价 `font.*`。同时提供扁平字段与 `font.*` 时 **`font.*` 优先**。
-    - `runs` / `paragraphs` 的 `start` / `length` 口径（UTF-16 code unit、含 `\r` / `\v`、越界 → `4002`）见 [字符区间口径](data-structures.md#pptparagraphstyle)。
+    - **应用顺序**：先 `text`（整框内容替换，如提供）→ 再 `font`（整框铺底）→ 再 `runs`（按数组序覆盖重叠区间）→ 最后 `paragraphs`（bullet）。因内容替换在先，`runs` / `paragraphs` 的 `start` / `length` **一律对齐替换后的最终文本**（详见下）。
+    - `runs` / `paragraphs` 的 `start` / `length` 口径（UTF-16 code unit、含 `\r` / `\v`、对齐最终文本、越界 → `4002`）见 [字符区间口径](data-structures.md#pptparagraphstyle)。
     - 各字体属性的 requirement set 及**反应式 3016 全或无**降级见 [`PptFont`](data-structures.md#pptfont)。
 
 **请求参数说明**:
@@ -1619,11 +1601,6 @@ interface TextBoxUpdates {
 | `updates.font` | [`PptFont`](data-structures.md#pptfont) | ❌ | 整框级字体格式 |
 | `updates.runs` | [`PptTextRun[]`](data-structures.md#ppttextrun) | ❌ | run 级局部格式（字符区间寻址，可多段） |
 | `updates.paragraphs` | [`PptParagraphStyle[]`](data-structures.md#pptparagraphstyle) | ❌ | 段落级项目符号（字符区间寻址） |
-| `updates.fontSize` | number | ❌ | ⚠️ Deprecated → `font.size` |
-| `updates.fontName` | string | ❌ | ⚠️ Deprecated → `font.name` |
-| `updates.color` | string | ❌ | ⚠️ Deprecated → `font.color` |
-| `updates.bold` | boolean | ❌ | ⚠️ Deprecated → `font.bold` |
-| `updates.italic` | boolean | ❌ | ⚠️ Deprecated → `font.italic` |
 
 !!! note "支持的元素类型"
     仅支持 `TextBox`、`Placeholder`、`GeometricShape` 类型的元素。
@@ -2232,7 +2209,7 @@ interface UpdateTableFormatResponse {
 **说明**: 更新元素的位置、尺寸或旋转角度。这是布局优化的核心操作，用于移动和缩放元素。
 
 !!! note "与 ppt:update:textBox 的关系"
-    `ppt:update:textBox` 用于更新文本**内容和样式**（text, fontSize, bold 等），
+    `ppt:update:textBox` 用于更新文本**内容和样式**（text、`font` 字体格式、`runs` 局部格式、bullet 等），
     `ppt:update:element` 用于更新**几何属性**（left, top, width, height, rotation）。
     两者互补，分别处理不同维度的更新。
 

--- a/docs/specification/events-ppt.md
+++ b/docs/specification/events-ppt.md
@@ -2104,30 +2104,34 @@ interface UpdateTableFormatRequest {
   timestamp?: number;        // 请求时间戳（毫秒），可选
   elementId: string;         // 表格元素 ID
   cellFormats?: Array<{
-    rowIndex: number;        // 行索引（从 0 开始）
-    columnIndex: number;     // 列索引（从 0 开始）
-    backgroundColor?: string;    // 背景颜色（十六进制）
-    fontSize?: number;           // 字号
-    fontColor?: string;          // 字体颜色（十六进制）
-    bold?: boolean;              // 粗体
-    italic?: boolean;            // 斜体
-    horizontalAlignment?: string; // 水平对齐（"Left" | "Center" | "Right"）
-    verticalAlignment?: string;   // 垂直对齐（"Top" | "Middle" | "Bottom"）
+    rowIndex: number;                                    // 行索引（从 0 开始）
+    columnIndex: number;                                 // 列索引（从 0 开始）
+    backgroundColor?: string;                            // 单元格填充色（十六进制）
+    font?: PptFont;                                      // 单元格字体格式（整格级，见 data-structures.md#pptfont）
+    horizontalAlignment?: ParagraphHorizontalAlignment;  // 水平对齐（7 值枚举）
+    verticalAlignment?: TextVerticalAlignment;           // 垂直对齐（6 值枚举）
   }>;
   rowFormats?: Array<{
-    rowIndex: number;        // 行索引（从 0 开始）
-    height?: number;         // 行高（磅）
-    backgroundColor?: string;    // 背景颜色（十六进制）
-    fontSize?: number;           // 字号
+    rowIndex: number;          // 行索引（从 0 开始）
+    height?: number;           // 行高（磅），行级 native
+    backgroundColor?: string;  // 背景色（逐格施加，见下）
+    font?: PptFont;            // 字体格式（逐格施加，见下）
   }>;
   columnFormats?: Array<{
-    columnIndex: number;     // 列索引（从 0 开始）
-    width?: number;          // 列宽（磅）
-    backgroundColor?: string;    // 背景颜色（十六进制）
-    fontSize?: number;           // 字号
+    columnIndex: number;       // 列索引（从 0 开始）
+    width?: number;            // 列宽（磅），列级 native
+    backgroundColor?: string;  // 背景色（逐格施加，见下）
+    font?: PptFont;            // 字体格式（逐格施加，见下）
   }>;
 }
 ```
+
+!!! note "版本门槛与降级（全或无，统一 1.9）"
+    本事件的字体 / 对齐 / 行高列宽 / 单元格填充均经 office.js `TableCell` / `TableRow` / `TableColumn`，其中 `TableCell.font` 访问器门槛为 **PowerPointApi 1.9**，会把复用的 [`PptFont`](data-structures.md#pptfont) 底层 1.4/1.8 属性**整体抬平到 1.9**。故本事件**有效门槛统一为 1.9**——不套用文本框的 1.4/1.8 分档，降级判定为单一 `isSetSupported("PowerPointApi","1.9")`：不满足 → 反应式 [`3016 API_NOT_SUPPORTED`](error-handling.md#api_not_supported-3016)（`details.requiredApiSet: "1.9"`），全或无、不做部分应用。
+    单元格**无 run 级**：office.js 未暴露单元格内字符区间寻址，`font` 作用于**整格**，不支持 `runs`。
+
+!!! warning "目标格前置校验（全或无，含合并单元格）"
+    应用前须前置校验本次涉及的所有单元格坐标（含由 `rowFormats` / `columnFormats` 展开到的单元格）：任一坐标越界、或命中**合并单元格的非左上格**（office.js `getCellOrNullObject` 返回空对象）→ 整请求按 [`4002 INVALID_PARAM`](error-handling.md) 失败，**不写入任何单元格**。不采用"跳过非法格"的部分成功语义，与文本框口径一致。
 
 **请求参数说明**:
 
@@ -2138,8 +2142,9 @@ interface UpdateTableFormatRequest {
 | `rowFormats` | Array | ❌ | 按行设置格式（应用到整行所有单元格） |
 | `columnFormats` | Array | ❌ | 按列设置格式（应用到整列所有单元格） |
 
-!!! note "优先级"
-    当多种格式同时应用到同一单元格时，优先级为：`cellFormats` > `columnFormats` > `rowFormats`。
+!!! note "行/列级即逐格扇出 + 优先级"
+    office.js 无"整行 / 整列字体"原生 API：`rowFormats[].font` / `columnFormats[].font` / `backgroundColor` 均为**逐格施加**到该行 / 列每个单元格的语法糖（唯有 `height` / `width` 是行 / 列 native 属性）。因此行 / 列级字体与单元格级字体走同一 `PptFont` 实体、同一 1.9 门槛。
+    当多级格式命中同一单元格时优先级：**`cellFormats` > `columnFormats` > `rowFormats`**（细粒度覆盖粗粒度），与 `backgroundColor` 现有口径一致。
 
 **请求示例**:
 
@@ -2149,10 +2154,10 @@ interface UpdateTableFormatRequest {
   "documentUri": "file:///Users/john/Documents/presentation.pptx",
   "elementId": "shape-030",
   "rowFormats": [
-    { "rowIndex": 0, "backgroundColor": "#4472C4", "fontSize": 14 }
+    { "rowIndex": 0, "backgroundColor": "#4472C4", "font": { "size": 14, "bold": true, "color": "#FFFFFF" } }
   ],
   "cellFormats": [
-    { "rowIndex": 1, "columnIndex": 0, "bold": true, "fontColor": "#333333" }
+    { "rowIndex": 1, "columnIndex": 0, "font": { "color": "#333333", "underline": "Single" }, "horizontalAlignment": "Center" }
   ]
 }
 ```
@@ -2192,7 +2197,8 @@ interface UpdateTableFormatResponse {
 |--------|------|
 | 4001 | `MISSING_PARAM` - 缺少 elementId |
 | 3003 | `OPERATION_FAILED` - 元素未找到或不是表格类型 |
-| 4002 | `INVALID_PARAM` - rowIndex/columnIndex 超出范围 |
+| 4002 | `INVALID_PARAM` - `rowIndex`/`columnIndex` 超出范围、命中合并单元格非左上格（空对象），或 `font.underline` / 对齐值不在枚举内 |
+| 3016 | `API_NOT_SUPPORTED` - 表格单元格字体 / 对齐 / 行高列宽需 PowerPointApi **1.9**，当前宿主不满足；`details.requiredApiSet` 标注所需版本 |
 | 3001 | `DOCUMENT_NOT_FOUND` - 文档未找到 |
 | 3000 | `OFFICE_API_ERROR` - Office API 调用错误 |
 


### PR DESCRIPTION
## 概述

`/ppt` 文字格式能力补齐 + **字体抽象统一收敛**（协议先行）。字体属性收敛为 `PptFont` 子对象，整框级 / run 级 / **表格单元格**三处复用同一实体；消除文本框与表格两处的散堆扁平字段。新增 run 级局部格式、删除线 / 双删除线、上下标、全 / 小型大写、17 值下划线枚举、项目符号、插入即带字体。

Closes A2C-SMCP/oasp-protocol#9 · 需求来源 JIAQIA/office4ai#45

## 可行性与设计来源

- 文本框能力经 `/cross-ask office-editor4ai`（Add-In / office.js）逐项复核**全部可落地**，并**纠正了 office4ai#45 的版本假设**：删除线/上下标/大写实为 **1.8**（非 1.4）、`getSubstring` 实为 **1.4**（非 1.5）、bullet `type`/`style` 为 **1.10**、下划线枚举为 **17 值**（非 15）、`bulletFormat` **无 character**。
- 表格单元格字体收敛经**二次 `/cross-ask office-editor4ai`** 复核：`TableCell.font` 即标准 `ShapeFont`，`PptFont` 12 属性**零丢失**、无需另立精简结构；版本门槛与文本框**不同**（见下）。

## 变更

### 1. 文本框字体收敛（`data-structures.md` / `ppt:update:textBox` / `ppt:insert:text`）

| 文件 | 变更 |
|------|------|
| `data-structures.md` | 新增 `PptFont`（12 属性，逐字段标 requirement set）、`ShapeFontUnderlineStyle`（17 值 PascalCase，对齐 office.js、零映射）、`PptTextRun`、`PptParagraphStyle`、`BulletFormat`（visible/type/style，**无 character**）、`BulletType` |
| `ppt:update:textBox` | `TextBoxUpdates` 加 `font` / `runs[]` / `paragraphs[]`；应用顺序 `text`→`font`→`runs`→`paragraphs` |
| `ppt:insert:text` | `TextInsertOptions` 加 `font`（插入即带字体） |

### 2. 表格单元格字体收敛（`ppt:update:tableFormat`）

| 变更 | 说明 |
|------|------|
| 收敛字体 | `cellFormats` / `rowFormats` / `columnFormats` 的扁平 `fontSize`/`fontColor`/`bold`/`italic` **移除**，统一改用 `font?: PptFont`（12 属性全量复用；`fontColor`→`color` 语义一致） |
| 行/列级字体（方案 A） | `rowFormats` / `columnFormats` 由「仅 fontSize」升级为完整 `font`，消除「行/列只能设字号」的割裂；`height`/`width` 保留为行/列 native |
| 对齐枚举 | 新增 `ParagraphHorizontalAlignment`（7 值）/ `TextVerticalAlignment`（6 值），替换原 `string` 并放开到 office.js 全枚举；对齐字段留单元格级、不并入 `PptFont` |

## 关键设计

- **font 子对象 + clean-break**：`/ppt` 为 Draft，文本框与表格的扁平字段一律**直接移除、不留 Deprecated 别名**——避免协议表面长期背负散堆字段（评审采纳）。
- **区间寻址**：`runs`/`paragraphs` 用 `{start,length,...}`；`start`/`length` 为 UTF-16 code unit，含 `\r`/`\v`。**与 `updates.text` 替换并存时先替换内容、offset 对齐替换后的最终文本**；越界 → `4002`。
- **枚举承载分档**：小而封闭者就地全枚举（underline 17 值 / 对齐 7·6 值，可校验）；大而易变者直通 `string`（bullet `style` 40+ 值，宿主校验、非法 → `4002`）。二者同为「零映射对齐宿主」，形态按集合规模分档。
- **跨命名空间不复用**：`/ppt` 的下划线（17 值 PascalCase）、对齐（`Center`/`Justify`）、表格字体（`PptFont`）**有意不复用** `/word` 的 `UnderlineStyle` / `Word.Alignment` / `CellFormat`——服务不同宿主 API、零映射。
- **降级（反应式全或无）**：
  - 文本框：宿主不满足**本次所含属性**的最高 requirement set（1.4/1.8/1.10 分档）→ `3016`。
  - 表格单元格：**统一 1.9**（`TableCell.font` 访问器门槛抬平底层 1.4/1.8），降级为单一 `isSetSupported("1.9")`；且**前置校验所有目标格**（含合并单元格空对象 / 越界）命中即整请求 `4002` 失败、不写任何格。均不引入「部分成功」语义。
- **无新错误码**：复用 `3016` / `4002`。

## 范围边界（不含）

- 段落级排版 / 字间距 / 超链接 / 竖排（走 OOXML 另案）；bullet 自定义字符 / 字体 / 颜色（office.js 不提供）。
- `/ppt` 只读摘要 `textInfo`（get 事件返回）：已是嵌套子对象、语义为「代表字体」而非可写字体，**不在本次写路径收敛范围**。
- `/word` 的 `TextFormat` / `CellFormat` 散堆字体字段：Word 为 ✅ Stable，收敛需单独 cross-ask（Word.js）+ 独立 PR，**不在本 PR 内**。
- Add-In 侧既有缺口（`insert:text` 字体哑参数 / `fillColor` 未透传 / underline 退化 / 表格「跳过非法格」的部分成功语义）由 office-editor4ai 单独立项修复。

## 验证

- [x] `mkdocs build --strict` 通过（唯一 INFO 为 events-excel.md 既有 `#excelInserttable` 断链，与本 PR 无关）

## 兼容性

`/ppt` 为 Draft。文本框 + 表格两处**移除扁平字体字段为破坏性收敛**，因 Draft（无稳定性承诺）可接受；调用方改用 `font.*`。新增枚举 / 可选字段向后兼容。目标 `0.4.0`。

## 后续（协议合并后，工具侧跟进；本 PR 不含工具代码）

- **office-editor4ai**（JIAQIA/office-editor4ai）：文本框消费 + 表格单元格字体扩到 12 属性 + 「跳过非法格」改全或无 + 3 处既有缺口修复。
- **office4ai**：DTO（`dtos/ppt.py`）+ MCP 工具 schema 跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
