### PR TITLE
fix(word): 消除 TextFormat 重复定义，统一权威单一来源 (#12 步骤1)

### DIFF
--- a/docs/specification/events-word.md
+++ b/docs/specification/events-word.md
@@ -808,19 +808,11 @@ interface InsertTextRequest {
   timestamp?: number;
   text: string;                              // 要插入的文本
   location?: "Cursor" | "Start" | "End";     // 插入位置，默认 "Cursor"
-  format?: TextFormat;                       // 可选的格式设置
-}
-
-interface TextFormat {
-  bold?: boolean;
-  italic?: boolean;
-  fontSize?: number;
-  fontName?: string;
-  color?: string;        // hex 颜色值，如 "#FF0000"
-  underline?: string;    // 下划线类型，如 "Single", "Double", "None"
-  styleName?: string;    // Word 样式名，如 "Heading 1", "Normal"
+  format?: TextFormat;                       // 可选的格式设置，定义见 data-structures.md#textformat
 }
 ```
+
+`TextFormat` 数据结构定义见 [data-structures.md#textformat](data-structures.md#textformat)（权威单一来源；`underline` 为 [`UnderlineStyle`](data-structures.md#underlinestyle) 枚举）。
 
 **请求示例**:
 
@@ -1029,7 +1021,7 @@ interface ReplaceTextRequest {
     matchWholeWord?: boolean; // 全词匹配，默认 false
     replaceAll?: boolean;    // 替换全部，默认 false
   };
-  format?: TextFormat;       // 可选的格式设置（定义见 word:insert:text）
+  format?: TextFormat;       // 可选的格式设置（定义见 data-structures.md#textformat）
 }
 ```
 


### PR DESCRIPTION
## 背景

#12（`/word` 字体收敛）评审发现的 🔴 真缺陷，与大收敛解耦，先独立修。

`TextFormat` 在规范里有**两处互相矛盾的定义**：

| 位置 | 字段数 | `underline` | `highlightColor` |
|------|--------|-------------|------------------|
| `data-structures.md`（权威） | 8 | `UnderlineStyle`（7 值枚举） | ✅ 有 |
| `events-word.md`（内联，`word:insert:text` 处） | 7 | `string`（"Single"/"Double"…） | ❌ 无 |

同名类型两份定义打架，双端按哪份实现都可能错。

## 改动（纯一致性修复，非破坏性）

- 删除 `events-word.md` 内联的 `interface TextFormat`。
- `word:insert:text` / `word:replace:text` 的回指统一改指向 `data-structures.md#textformat`（此前 `word:replace:text` 写的是"定义见 word:insert:text"）。
- 采用 `data-structures.md` 为**权威单一来源**：`underline` = `UnderlineStyle`（7 值小写枚举）、含 `highlightColor`。

## 说明

- 内联版 `underline` 曾以 `"Single"`/`"Double"`（PascalCase）举例，而权威 `UnderlineStyle` 为小写。本 PR 以既有权威定义为准；**underline 值大小写在 Word.js 侧的最终口径留待 #12 第 2 步 `/cross-ask office-editor4ai` 复核**（若届时确认宿主用 PascalCase，再统一调整 `UnderlineStyle`，属独立变更）。
- 不含 `WordFont` 收敛本身（#12 主体，Stable 破坏性变更，需 cross-ask + 独立 PR）。
- `mkdocs build --strict` 通过。

Refs #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)