### PR TITLE
refactor(word): /word 字体收敛为 WordFont + 修正 UnderlineStyle (closes #12)

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -9,6 +9,24 @@
 
 ## [Unreleased]
 
+### /word 字体字段收敛为 WordFont + 修正 UnderlineStyle（含 Stable 破坏性变更）
+
+延续 #10 的字体抽象统一，把 `/word` 散落在 `TextFormat` / `CellFormat` 上的字体字段收敛为统一实体 **`WordFont`**（`bold`/`italic`/`underline`/`size`/`name`/`color`/`highlightColor`，两处复用）。经 `/cross-ask office-editor4ai` 复核可行（全 `Word.Font`、文本场景 WordApi 1.1），并**纠正了现协议 `UnderlineStyle` 的严重错误**。
+
+| 变更类型 | 位置 | 说明 |
+|----------|------|------|
+| 新增（数据结构） | `data-structures.md` | `WordFont`（7 属性字体子对象，对齐 `Word.Font`、零映射） |
+| **修正（错误值）** | `data-structures.md` `UnderlineStyle` | 原 7 值小写（`single`/`double`/…）**三重错误**：大小写全错、`dashed` 为**非法值**（Word 用 `DashLine`）、且为漏项子集。改为对齐 `Word.UnderlineType` 的 **18 值 PascalCase**（`None` + 17 可 SET 值，排除仅回读 `Mixed` 与废弃 `Hidden`/`DotLine`）。已部署 Add-In 本就用 PascalCase 全枚举，本次收敛掉文档与实现的漂移 |
+| **移除 + 收敛（Stable 破坏性，clean-break）** | `TextFormat`（`word:insert:text` / `replace:selection` / `replace:text`） | 扁平 `bold`/`italic`/`underline`/`fontSize`/`fontName`/`color`/`highlightColor` **删除**，收敛为 `TextFormat = { font?: WordFont, styleName? }`。经确认无外部已部署发送方，直接 clean-break、不留兼容窗口 |
+| **移除 + 收敛（Draft 破坏性）** | `CellFormat`（`word:update:tableCell`） | 扁平 `fontName`/`fontSize`/`fontColor`/`bold`/`italic` **删除**，收敛为 `font?: WordFont`（`fontColor`→`color`）；单元格因此获得 `underline`/`highlightColor`。对齐 / `backgroundColor` 保留顶层 |
+| 澄清（既有一致性） | `data-structures.md` | `TextFormat.styleName` 经 `styleBuiltIn`（中文宿主必需，实际 WordApi 1.3）；`highlightColor` 桌面端仅 15 预置色、非自由 RGB、`null` 清除；`CellFormat` 全字段有效门槛 WordApi 1.3 |
+
+**版本门槛**：文本字体 **WordApi 1.1**（几乎恒满足）；表格单元格字体经 `cell.body.font` 抬至 **1.3**（与 `CellFormat` 其余字段同档，不额外抬高）；`styleName` 可靠应用（`styleBuiltIn`）需 **1.3**。降级同 `/ppt` 反应式 `3016`。
+
+**跨命名空间**：`/word` `UnderlineStyle`（18 值，对齐 `Word.UnderlineType`）与 `/ppt` `ShapeFontUnderlineStyle`（17 值，对齐 office.js）字面量不同（虚线 `DashLine` vs `Dash`），**有意不复用**。
+
+**兼容性**：`TextFormat`（Stable）与 `CellFormat`（Draft）均破坏性收敛；因确认无外部消费方，`/word` 亦采 clean-break。工具侧（`JIAQIA/office-editor4ai`）跟进消费——Add-In 现状已是 PascalCase 全枚举，underline 侧零改动，主要改动为扁平→嵌套 schema 归一化。目标 `0.4.0`。
+
 ### /ppt 文字格式能力补齐 + 字段收敛（Draft 破坏性收敛）
 
 为 `/ppt` 文字工具补齐一批 office.js 原生支持的常规文字格式能力：run 级局部格式、删除线/双删除线、上标/下标、全大写/小型大写、多下划线样式、项目符号、插入即带字体。**字段结构统一收敛为 `font` 子对象**：`insert:text` / `update:textBox` 原有的扁平 `fontSize`/`fontName`/`color`/`bold`/`italic` **直接移除**（不保留 Deprecated 别名），改由 `font.*` 承载——整框级与 run 级复用同一 `PptFont`。因 `/ppt` 为 Draft，允许此破坏性收敛，避免协议表面长期背负散堆的扁平字段。

--- a/docs/specification/data-structures.md
+++ b/docs/specification/data-structures.md
@@ -85,42 +85,59 @@ type SelectionType =
 
 ### TextFormat
 
-文本格式定义。
+文本格式定义：字体格式收敛到 [`WordFont`](#wordfont)，`styleName`（Word 样式）为独立关注点。
 
 ```typescript
 interface TextFormat {
-  bold?: boolean;          // 粗体
-  italic?: boolean;        // 斜体
-  underline?: UnderlineStyle;  // 下划线样式
-  fontSize?: number;       // 字号（磅）
-  fontName?: string;       // 字体名称
-  color?: string;          // 文字颜色（十六进制，如 "#FF0000"）
-  highlightColor?: string; // 高亮颜色
-  styleName?: string;      // Word 样式名称
+  font?: WordFont;       // 字体格式，见 #wordfont
+  styleName?: string;    // Word 内置样式名（如 "Heading 1"），经 styleBuiltIn 应用
 }
 ```
 
 !!! important "样式优先级"
-    当 `styleName` 与直接格式属性同时存在时，**直接格式属性优先级更高**。
+    当 `styleName` 与 `font` 同时存在时，**`font` 优先级更高**。处理顺序：先应用 `styleName` 指定的样式，再用 `font` 覆盖。
 
-    处理顺序：
-    1. 先应用 `styleName` 指定的样式
-    2. 再用直接格式属性覆盖
+!!! note "styleName 的宿主口径"
+    `styleName` 经 Word.js `range.styleBuiltIn` 应用（内置样式需去空格 PascalCase：`"Heading 1"` → `Heading1`），未命中再回退 `range.style`。**中文 / 非英文宿主必须走 `styleBuiltIn`**（`range.style = "Heading 1"` 会抛 `InvalidArgument`），故 `styleName` 的可靠应用实际需 **WordApi 1.3**。
+
+### WordFont
+
+Word 字体格式。整段（`TextFormat.font`）与表格单元格（`CellFormat.font`）复用同一结构。所有字段可选，未提供的属性保持原样。对齐 Word.js `Word.Font`，双端零映射。
+
+```typescript
+interface WordFont {
+  bold?: boolean;                  // 粗体                          [WordApi 1.1]
+  italic?: boolean;                // 斜体                          [1.1]
+  underline?: UnderlineStyle;      // 下划线样式（见下）            [1.1]
+  size?: number;                   // 字号（磅）                    [1.1]
+  name?: string;                   // 字体名称                      [1.1]
+  color?: string;                  // 文字颜色（十六进制 #RRGGBB 或色名） [1.1]
+  highlightColor?: string | null;  // 高亮色（见下；null = 清除）   [1.1]
+}
+```
+
+!!! note "requirement set 与降级"
+    文本字体全部字段经 Word.js `range.font`（`Word.Font`），**统一 WordApi 1.1**，几乎所有宿主满足、无访问器抬平。用于表格单元格时经 `cell.body.font`，因 `TableCell` / `TableCell.body` 访问器门槛升至 **WordApi 1.3**（与 [`CellFormat`](#cellformat) 其余字段同档，不额外抬高）。宿主不满足时按事件定义走反应式 [`3016 API_NOT_SUPPORTED`](error-handling.md#api_not_supported-3016)。
+
+!!! warning "highlightColor ≠ color（桌面端预置色吸附）"
+    `highlightColor` 取值为十六进制 `#RRGGBB` 或 Word 预置色名（如 `"Yellow"`），`null` 表示**清除高亮**。⚠️ **桌面版 Word 仅支持 15 个预置高亮色**（Yellow / Lime / Turquoise / Pink / Blue / Red / DarkBlue / Teal / Green / Purple / DarkRed / Olive / Gray / LightGray / Black），传任意 `#RRGGBB` 会被**吸附到最近的预置色**——故 `highlightColor` 不是自由 RGB（与 `color` 不同）；需精确可控时建议直接传上述 15 个预置色名。
 
 ### UnderlineStyle
 
-下划线样式枚举。
+Word 下划线样式枚举（对齐 Word.js `Word.UnderlineType`，PascalCase，双端零映射）。列出全部**可 SET** 值，排除仅回读的 `Mixed` 与已废弃的 `Hidden` / `DotLine`。
 
 ```typescript
 type UnderlineStyle =
-  | "none"                 // 无下划线
-  | "single"               // 单下划线
-  | "double"               // 双下划线
-  | "dotted"               // 点线
-  | "dashed"               // 虚线
-  | "thick"                // 粗下划线
-  | "wave";                // 波浪线
+  | "None"
+  | "Single" | "Word" | "Double" | "Thick"
+  | "Dotted" | "DottedHeavy"
+  | "DashLine" | "DashLineHeavy" | "DashLineLong" | "DashLineLongHeavy"
+  | "DotDashLine" | "DotDashLineHeavy" | "TwoDotDashLine" | "TwoDotDashLineHeavy"
+  | "Wave" | "WaveHeavy" | "WaveDouble";
 ```
+
+!!! info "与 /ppt 的 ShapeFontUnderlineStyle 有意不同"
+    本枚举 PascalCase、对齐 Word.js `Word.UnderlineType`；`/ppt` 的 [`ShapeFontUnderlineStyle`](#shapefontunderlinestyle) 对齐 office.js PowerPoint。二者服务不同宿主 API、字面量不同（虚线 Word 为 `DashLine`、PPT 为 `Dash`），**有意不复用**。
 
 ---
 
@@ -183,7 +200,7 @@ type ShapeFontUnderlineStyle =
 ```
 
 !!! info "与 Word 的 UnderlineStyle 有意不同"
-    `/word` 的 [`UnderlineStyle`](#underlinestyle) 是 7 值小写（`single` / `double` / …），映射 Word.js；PPT 的 `ShapeFontUnderlineStyle` 是 17 值 PascalCase，直接对齐 office.js PowerPoint 的同名枚举。二者服务不同宿主 API，故**不复用**——这是有意的跨命名空间差异，非命名不一致。
+    `/word` 的 [`UnderlineStyle`](#underlinestyle) 是 18 值 PascalCase（对齐 Word.js `Word.UnderlineType`）；PPT 的 `ShapeFontUnderlineStyle` 是 17 值 PascalCase（对齐 office.js PowerPoint 的同名枚举）。二者对齐不同宿主 API、字面量不同（如虚线 Word 为 `DashLine`、PPT 为 `Dash`），故**不复用**——这是有意的跨命名空间差异，非命名不一致。
 
 ### PptTextRun
 
@@ -361,7 +378,7 @@ interface ReplaceContent {
 ```
 
 !!! important "格式优先级"
-    - `format`（最高优先级）：包含直接格式属性和 `format.styleName`
+    - `format`（最高优先级）：包含 `format.font`（字体）和 `format.styleName`
     - `styleName`（仅在 `format` 未提供时使用）
     - 默认保持选区原有格式
 
@@ -416,25 +433,24 @@ type TableInsertLocation =
 interface CellFormat {
   horizontalAlignment?: "Left" | "Centered" | "Right" | "Justified";  // 对应 Word.Alignment
   verticalAlignment?: "Top" | "Center" | "Bottom";                    // 对应 Word.VerticalAlignment
-  backgroundColor?: string;       // 背景颜色（十六进制，如 "#4472C4"）— 对应 cell.shadingColor
-  fontName?: string;              // 字体名称（应用到整个单元格 body，会覆盖原段落字体）
-  fontSize?: number;              // 字号（磅）
-  fontColor?: string;             // 字体颜色（十六进制，如 "#333333"）
-  bold?: boolean;                 // 粗体
-  italic?: boolean;               // 斜体
+  backgroundColor?: string;   // 背景色（十六进制，如 "#4472C4"）— 对应 cell.shadingColor
+  font?: WordFont;            // 单元格字体格式（整刷，见下），见 #wordfont
 }
 ```
 
 !!! note "命名对齐 Office.js"
-    枚举值刻意与 Word JavaScript API 的 `Word.Alignment` / `Word.VerticalAlignment` 完全一致（注意 `Centered` / `Justified` 是过去分词形），便于 Add-In 直接 `cast` 不做映射。
+    对齐枚举值刻意与 Word JavaScript API 的 `Word.Alignment` / `Word.VerticalAlignment` 完全一致（注意 `Centered` / `Justified` 是过去分词形），便于 Add-In 直接 `cast` 不做映射。
 
-!!! note "整刷语义"
-    `fontName` / `fontSize` / `fontColor` / `bold` / `italic` 作用于整个单元格 body，会覆盖单元格内所有段落与 Run 的字体设置。这是 Word.js 的固有行为，不是协议保留的灵活度。
+!!! note "字体收敛为 WordFont（整刷语义）"
+    单元格字体统一走 [`WordFont`](#wordfont)（`fontColor` 已并入 `font.color`；单元格因此获得 `underline` / `highlightColor` 等全部 7 属性）。`font` 经 Word.js `cell.body.font` 应用，**作用于整个单元格 body、覆盖单元格内所有段落与 Run 的字体**——这是 Word.js 的固有行为（对 `Body.font` 赋值即整体套用），不是协议保留的灵活度。
+
+!!! note "requirement set"
+    `CellFormat` 全字段有效门槛 **WordApi 1.3**：`TableCell` / `TableCell.body`、`cell.shadingColor`、`horizontalAlignment` / `verticalAlignment` 均为 1.3。`font` 的字体属性本身是 1.1，经单元格访问器（`cell.body.font`）抬至 1.3，与本结构其余字段同档、不额外抬高。
 
 !!! note "单元格内边距"
     Word JavaScript API 的单元格内边距是**表级 API**（`Word.Table.setCellPadding`），无法逐单元格设置。如需调整内边距，请通过 `word:update:tableFormat.styleOptions.cellPadding` 在表级配置。
 
-> 该结构仅 `/word` 命名空间引用（对齐 Word.js：[`UnderlineStyle`](#underlinestyle) 7 值小写、`Word.Alignment` 的 `Centered` / `Justified`）。`/ppt` 的 [`ppt:update:tableFormat`](events-ppt.md#pptupdatetableformat) **有意不复用本结构**，改用 [`PptFont`](#pptfont) + [`ParagraphHorizontalAlignment`](#paragraphhorizontalalignment) / [`TextVerticalAlignment`](#textverticalalignment)（对齐 office.js PowerPoint、17 值 PascalCase 下划线、`Center` / `Justify`）——与 underline 枚举同理，服务不同宿主 API、零映射，跨命名空间不复用。
+> 该结构仅 `/word` 命名空间引用（对齐 Word.js：[`UnderlineStyle`](#underlinestyle) 18 值 PascalCase 对齐 `Word.UnderlineType`、`Word.Alignment` 的 `Centered` / `Justified`）。`/ppt` 的 [`ppt:update:tableFormat`](events-ppt.md#pptupdatetableformat) **有意不复用本结构**，改用 [`PptFont`](#pptfont) + [`ParagraphHorizontalAlignment`](#paragraphhorizontalalignment) / [`TextVerticalAlignment`](#textverticalalignment)（对齐 office.js PowerPoint、17 值 PascalCase 下划线、`Center` / `Justify`）——与 underline 枚举同理，服务不同宿主 API、零映射，跨命名空间不复用。
 
 ---
 

--- a/docs/specification/events-word.md
+++ b/docs/specification/events-word.md
@@ -795,9 +795,9 @@ interface GetStylesResponse {
 **说明**: 在指定位置插入文本。
 
 !!! important "样式优先级规则"
-    当同时指定直接格式（如 `bold`、`fontSize`）和 `styleName` 时，**直接格式优先级高于样式名**。
+    当同时指定 `format.font`（[`WordFont`](data-structures.md#wordfont)）和 `styleName` 时，**`font` 优先级高于样式名**。
 
-    即：先应用 `styleName` 指定的样式，再覆盖应用直接格式属性。
+    即：先应用 `styleName` 指定的样式，再覆盖应用 `format.font`。
 
 **请求数据**:
 
@@ -823,10 +823,7 @@ interface InsertTextRequest {
   "text": "这是新插入的文本",
   "location": "Cursor",
   "format": {
-    "bold": true,
-    "fontSize": 14,
-    "fontName": "微软雅黑",
-    "color": "#FF0000"
+    "font": { "bold": true, "size": 14, "name": "微软雅黑", "color": "#FF0000" }
   }
 }
 ```
@@ -872,7 +869,7 @@ interface InsertTextResponse {
     选区必须非空。如果选区为空，将返回错误码 `SELECTION_EMPTY` (3002)。
 
 !!! important "格式优先级规则"
-    - `format`（最高优先级）：包含直接格式属性和 `format.styleName`
+    - `format`（最高优先级）：包含 `format.font`（字体）和 `format.styleName`
     - `styleName`（仅在 `format` 未提供时使用）
     - 默认保持选区原有格式
 
@@ -903,7 +900,7 @@ interface ReplaceContent {
   "content": {
     "text": "新的替换文本",
     "format": {
-      "bold": true
+      "font": { "bold": true }
     }
   }
 }
@@ -992,8 +989,8 @@ interface ReplaceSelectionResponse {
 **说明**: 查找并替换文档中的文本。
 
 !!! important "样式优先级规则"
-    当同时指定直接格式（如 `bold`、`fontSize`）和 `styleName` 时，**直接格式优先级高于样式名**。
-    即：先应用 `styleName` 指定的样式，再覆盖应用直接格式属性。
+    当同时指定 `format.font`（[`WordFont`](data-structures.md#wordfont)）和 `styleName` 时，**`font` 优先级高于样式名**。
+    即：先应用 `styleName` 指定的样式，再覆盖应用 `format.font`。
 
 !!! note "特殊字符搜索"
     `searchText` 和 `replaceText` 支持 Word 特殊字符记号来匹配不可见字符。**不要使用 `\n` 等转义字符**，而应使用下表中的 Word 记号：
@@ -1039,9 +1036,7 @@ interface ReplaceTextRequest {
     "replaceAll": true
   },
   "format": {
-    "bold": true,
-    "fontSize": 14,
-    "color": "#FF0000"
+    "font": { "bold": true, "size": 14, "color": "#FF0000" }
   }
 }
 ```
@@ -1255,8 +1250,7 @@ interface AppendTextRequest {
   "text": "这是追加的文本",
   "location": "End",
   "format": {
-    "bold": true,
-    "fontSize": 12
+    "font": { "bold": true, "size": 12 }
   }
 }
 ```
@@ -1738,8 +1732,7 @@ interface UpdateTableCellRequest {
       "format": {
         "horizontalAlignment": "Centered",
         "backgroundColor": "#4472C4",
-        "fontColor": "#FFFFFF",
-        "bold": true
+        "font": { "color": "#FFFFFF", "bold": true }
       }
     }
   ]


### PR DESCRIPTION
## 概述

延续 #10（`/ppt` → `PptFont`）把字体抽象统一到 `/word`：`TextFormat` / `CellFormat` 散落字体字段收敛为统一实体 **`WordFont`**。经 `/cross-ask office-editor4ai` 复核可行（全 `Word.Font`、文本场景 WordApi 1.1），并**纠正了现协议 `UnderlineStyle` 的严重错误**。

Closes #12 · 先例 #10 · 评审工具 #11（`/protocol-design-review`）

## 变更

| 类型 | 位置 | 说明 |
|------|------|------|
| 新增 | `data-structures.md` `WordFont` | 7 属性字体子对象（`bold`/`italic`/`underline`/`size`/`name`/`color`/`highlightColor`），对齐 `Word.Font` 零映射；`TextFormat` 与 `CellFormat` 复用 |
| **修正（错误值）** | `UnderlineStyle` | 原 7 值小写**三重错误**：大小写全错、`dashed` 为**非法值**（Word 实为 `DashLine`）、漏项子集 → 对齐 `Word.UnderlineType` 的 **18 值 PascalCase**（排除仅回读 `Mixed`、废弃 `Hidden`/`DotLine`）。Add-In 现状本就是 PascalCase 全枚举，本次收敛掉文档/实现漂移 |
| **移除+收敛（Stable，clean-break）** | `TextFormat`（`word:insert:text`/`replace:selection`/`replace:text`） | 扁平字段删除 → `{ font?: WordFont, styleName? }`。经确认无外部已部署发送方，直接 clean-break |
| **移除+收敛（Draft，clean-break）** | `CellFormat`（`word:update:tableCell`） | 扁平字体删除 → `font?: WordFont`（`fontColor`→`color`）；单元格获得 `underline`/`highlightColor`；对齐/`backgroundColor` 留顶层 |
| 澄清 | `data-structures.md` | `styleName` 经 `styleBuiltIn`（中文宿主必需，实际 1.3）；`highlightColor` 桌面端仅 15 预置色、非自由 RGB、`null` 清除；`CellFormat` 全字段 WordApi 1.3 |
| 同步 | `events-word.md` | 5 处示例扁平→嵌套 `font`、优先级说明；修正 PPT→Word 反向 note「7 值小写」→「18 值 PascalCase」 |

## 关键决策（用户拍板）

- **`TextFormat`（Stable）直接 clean-break**，不留双读兼容窗口——已确认无外部已部署发送方。
- **`WordFont` 就 7 字段**——忠实映射现有 `/word` 能力；`strikethrough`/上下标（office.js 侧免费 1.1）按需再加，`allCaps`/`smallCaps`（桌面限定 1.3）不加。

## 版本门槛

文本字体 **WordApi 1.1**（几乎恒满足）；表格单元格字体经 `cell.body.font` 抬至 **1.3**（与 `CellFormat` 其余字段同档，不额外抬高）；`styleName`（`styleBuiltIn`）需 **1.3**。降级同 `/ppt` 反应式 `3016`。

## 跨命名空间

`/word` `UnderlineStyle`（18 值，`Word.UnderlineType`）与 `/ppt` `ShapeFontUnderlineStyle`（17 值，office.js）字面量不同（虚线 `DashLine` vs `Dash`），**有意不复用**。

## 验证

- [x] `mkdocs build --strict` 通过

## 兼容性 & 后续

`TextFormat`（Stable）+ `CellFormat`（Draft）均破坏性收敛；因无外部消费方，`/word` 亦 clean-break。目标 `0.4.0`。工具侧（`JIAQIA/office-editor4ai`）跟进：扁平→嵌套 schema 归一化（underline 侧零改动，Add-In 已是 PascalCase 全枚举）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)