### PR TITLE
feat(ppt): ppt:insert:shape 补 font?: PptFont —— 插入形状即带字体（对齐 insert:text）(#15)

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -38,6 +38,7 @@
 | 新增（数据结构） | `data-structures.md` | `PptFont`（整框级 / run 级共用的字体子对象，12 属性含删除线/上下标/大写/下划线）、`ShapeFontUnderlineStyle`（17 值 PascalCase 枚举）、`PptTextRun`（`{start,length,font}` run 级寻址）、`PptParagraphStyle`（`{start,length,bulletFormat}` 段落级寻址）、`BulletFormat`（`visible`/`type`/`style`，**无 `character`**）、`BulletType` 枚举 |
 | 变更（事件字段） | `events-ppt.md` `ppt:update:textBox` | `TextBoxUpdates` 新增 `font` / `runs[]` / `paragraphs[]`；应用顺序 `text`→`font`→`runs`→`paragraphs`（内容替换在先，区间寻址对齐替换后最终文本；后者覆盖重叠区间） |
 | 变更（事件字段） | `events-ppt.md` `ppt:insert:text` | `TextInsertOptions` 新增 `font`（插入即带字体，语义等价「插入 + 格式」复合操作） |
+| 变更（事件字段） | `events-ppt.md` `ppt:insert:shape` | `ShapeInsertOptions` 新增 `font`（插入即带字体，复用 `PptFont`，字段 / 语义与 `insert:text` 一致）；`font` / `text` 仅适用 text-capable 形状（`TextBox` + 除 `Line` 外的几何形状），用于无文本框的 `Line` → 前置 `4002 INVALID_PARAM`（语义误用，与能力不足 `3016` 分离）；`text` 与 `font` 并存施加顺序 `text`→`font` |
 | **移除（Draft 破坏性收敛）** | `events-ppt.md` | `TextBoxUpdates` 与 `TextInsertOptions` 的扁平 `fontSize`/`fontName`/`color`/`bold`/`italic` **删除**，统一改用 `font.*`；`/ppt` 为 Draft，不保留 Deprecated 别名 |
 | 复用（无新错误码） | `events-ppt.md` / `error-handling.md` | 区间越界 / 枚举非法复用 [`4002 INVALID_PARAM`](../specification/error-handling.md)；requirement set 不满足复用 [`3016 API_NOT_SUPPORTED`](../specification/error-handling.md#api_not_supported-3016)（`details.requiredApiSet` 标注版本） |
 

--- a/docs/specification/data-structures.md
+++ b/docs/specification/data-structures.md
@@ -143,11 +143,11 @@ type UnderlineStyle =
 
 ## PPT 文本格式（/ppt）
 
-> 以下结构服务于 [`ppt:update:textBox`](events-ppt.md#pptupdatetextbox) 与 [`ppt:insert:text`](events-ppt.md#pptinserttext)。字体属性统一收敛到 `PptFont`，**整框级与 run 级复用同一结构**。每个属性标注其最低 PowerPointApi requirement set；宿主不满足时按事件定义走**反应式** [`3016 API_NOT_SUPPORTED`](error-handling.md#api_not_supported-3016) 处理。
+> 以下结构服务于 [`ppt:update:textBox`](events-ppt.md#pptupdatetextbox)、[`ppt:insert:text`](events-ppt.md#pptinserttext) 与 [`ppt:insert:shape`](events-ppt.md#pptinsertshape)。字体属性统一收敛到 `PptFont`，**整框级与 run 级复用同一结构**。每个属性标注其最低 PowerPointApi requirement set；宿主不满足时按事件定义走**反应式** [`3016 API_NOT_SUPPORTED`](error-handling.md#api_not_supported-3016) 处理。
 
 ### PptFont
 
-PPT 文字字体格式。整框级（`TextBoxUpdates.font` / `TextInsertOptions.font`）与 run 级（`PptTextRun.font`）共用本结构。所有字段可选，未提供的属性保持原样。
+PPT 文字字体格式。整框级（`TextBoxUpdates.font` / `TextInsertOptions.font` / `ShapeInsertOptions.font`）与 run 级（`PptTextRun.font`）共用本结构。所有字段可选，未提供的属性保持原样。
 
 ```typescript
 interface PptFont {

--- a/docs/specification/events-ppt.md
+++ b/docs/specification/events-ppt.md
@@ -929,11 +929,23 @@ interface ShapeInsertOptions {
   fillColor?: string;        // 填充颜色（十六进制），默认 "#4472C4"
   borderColor?: string;      // 边框颜色（十六进制），默认 "#2E5090"
   borderWidth?: number;      // 边框宽度（磅），默认 2
-  text?: string;             // 形状内文本
+  text?: string;             // 形状内文本（仅 text-capable 形状）
+  font?: PptFont;            // 插入形状的字体格式（仅 text-capable 形状），见 data-structures.md#pptfont
 }
 ```
 
+!!! note "插入即带字体格式（仅 text-capable 形状）"
+    `options.font`（`PptFont`）在插入形状的同时应用字体格式，语义等价「插入 + 格式」的一次性复合操作，与 [`ppt:insert:text`](#pptinserttext) 的 `font` 字段 / 语义一致。
+
+    **仅适用 text-capable 形状**——`TextBox` 及具备文本框的几何形状（`Rectangle` / `RoundedRectangle` / `Circle` / `Oval` / `Triangle` / `Star` / `Arrow`）。对**无文本框**的形状（`Line`）传入 `font`（或 `text`）→ 前置 `4002 INVALID_PARAM`（语义误用，静态拒绝、非静默忽略）。
+
+    当 `text` 与 `font` 并存时，施加顺序为 `text` → `font`——**`font` 作用于插入后的最终文本内容**。未提供 `text` 时，`font` 作用于形状文本框的默认字体（空文本框，后续输入继承）。
+
+    各属性的 requirement set（基础属性 1.4 / 删除线·上下标·大写 1.8）与降级同 [`PptFont`](data-structures.md#pptfont)：宿主 requirement set 不满足时走**反应式** [`3016 API_NOT_SUPPORTED`](error-handling.md#api_not_supported-3016) **整体失败（全或无）**——能力不足（`3016`）与语义误用（`4002`）语义分离。
+
 **形状类型说明**:
+
+> 除 `Line` 外的所有形状均为 text-capable（接受 `text` / `font`）；`Line` 无文本框。
 
 | 类型 | 说明 |
 |------|------|
@@ -942,10 +954,26 @@ interface ShapeInsertOptions {
 | `Circle` | 圆形 |
 | `Oval` | 椭圆 |
 | `Triangle` | 三角形 |
-| `Line` | 线条 |
-| `Arrow` | 箭头 |
+| `Line` | 线条（无文本框，不接受 `text` / `font`） |
+| `Arrow` | 箭头（块状箭头，含文本框，接受 `text` / `font`） |
 | `Star` | 星形 |
 | `TextBox` | 文本框 |
+
+**请求参数说明**:
+
+| 参数 | 类型 | 必需 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `shapeType` | `ShapeType` | ✅ | - | 形状类型（见上「形状类型说明」） |
+| `slideIndex` | number | ❌ | 当前幻灯片 | 目标幻灯片索引（从 0 开始） |
+| `left` | number | ❌ | 居中 | X 坐标（磅） |
+| `top` | number | ❌ | 居中 | Y 坐标（磅） |
+| `width` | number | ❌ | 100 | 宽度（磅） |
+| `height` | number | ❌ | 100 | 高度（磅） |
+| `fillColor` | string | ❌ | `#4472C4` | 填充颜色（十六进制） |
+| `borderColor` | string | ❌ | `#2E5090` | 边框颜色（十六进制） |
+| `borderWidth` | number | ❌ | 2 | 边框宽度（磅） |
+| `text` | string | ❌ | - | 形状内文本（仅 text-capable 形状；用于 `Line` → `4002`） |
+| `font` | [`PptFont`](data-structures.md#pptfont) | ❌ | - | 插入形状的字体格式（仅 text-capable 形状；用于 `Line` → `4002`） |
 
 **请求示例**:
 
@@ -962,7 +990,8 @@ interface ShapeInsertOptions {
     "height": 100,
     "fillColor": "#4472C4",
     "borderColor": "#2E5090",
-    "text": "点击这里"
+    "text": "点击这里",
+    "font": { "size": 18, "name": "微软雅黑", "color": "#FFFFFF", "bold": true }
   }
 }
 ```
@@ -1009,7 +1038,8 @@ interface InsertShapeResponse {
 | 错误码 | 说明 |
 |--------|------|
 | 4001 | `MISSING_PARAM` - 缺少 shapeType 参数 |
-| 4002 | `INVALID_PARAM` - shapeType 不支持或 slideIndex 超出范围 |
+| 4002 | `INVALID_PARAM` - shapeType 不支持、slideIndex 超出范围、`font` / `text` 用于无文本框的形状（如 `Line`），或 `font.underline` 不在枚举内 |
+| 3016 | `API_NOT_SUPPORTED` - `font` 所含属性所需 PowerPointApi requirement set（删除线 / 上下标 / 大写 = 1.8）在当前宿主不满足；`details.requiredApiSet` 标注所需版本 |
 | 3001 | `DOCUMENT_NOT_FOUND` - 文档未找到 |
 | 3000 | `OFFICE_API_ERROR` - Office API 调用错误 |
 


### PR DESCRIPTION
## 概述

`ppt:insert:shape` 的 `ShapeInsertOptions` 增补 `font?: PptFont`，镜像 `ppt:insert:text` 已有的「插入即带字体」复合语义。复用 `data-structures.md#PptFont`，**无新数据结构**。补齐 office4ai#45 验收项「插入文字/**形状**时可一步带上字体字号」中此前遗漏的形状半边（0.4.0 已给 `insert:text` 补 `font`）。

Closes #15

## 消费方验证（Step 3.5 cross-ask，已消化）

经 `/cross-ask office-editor4ai`（Office.js Add-In）双向验证，敲定 shape 特有降级语义（写入协议）：

- **可行性**：几何形状 `textFrame.textRange.font` 与 `.text` 同源可写，requirement set 与 TextBox 一致（基础属性 1.4 / 删除线·上下标·大写 1.8）。
- **text-capable 白名单**：`TextBox` + 除 `Line` 外的几何形状（`Arrow` 为块状箭头、含文本框、text-capable）。无文本框的 `Line` 传入 `font`（或 `text`）→ 前置 **`4002 INVALID_PARAM`** 静态拒绝，非静默忽略。
- **错误码语义分离**：`4002`（语义误用，静态前置） ≠ `3016`（能力不足，反应式全或无）。
- **施加顺序** `text` → `font`；未提供 `text` 时 `font` 落形状文本框默认字体。

## 变更内容

| 文件 | 变更 |
|------|------|
| `docs/specification/events-ppt.md` | `ShapeInsertOptions` 增 `font?: PptFont`；新增「插入即带字体」note（含 text-capable / `4002` / `3016` / 施加顺序）；补齐 `ppt:insert:shape` 请求参数说明表（与 `insert:text` 对齐）；示例加 `font`；错误表补 `3016`、修订 `4002`；形状类型表标注 `Line`/`Arrow` 文本能力 |
| `docs/specification/data-structures.md` | `PptFont` 服务事件列表 + 整框级来源列表加入 `ppt:insert:shape` / `ShapeInsertOptions.font` |
| `docs/appendix/changelog.md` | `[Unreleased]` → 0.4.0 `/ppt` 段增补 `insert:shape` `font` 行 |

## 兼容性

`/ppt` = Draft，新增可选字段**向后兼容**；不改既有字段语义。随 0.4.0 一并发版。

## 质量门控

- ✅ `uv run mkdocs build` 通过（无新增 broken-link 告警）
- ✅ 隔离上下文 `code-reviewer` 子代理复审：**无 🔴 阻断 / 无 🟠 应修**；采纳 2 项 🟡 打磨（形状类型表自足性说明、font-only 语义补充）；跨文件锚点/引用同步核验通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
